### PR TITLE
Fix Release workflow so goreleaser actually publishes

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -2,8 +2,12 @@ name: goreleaser
 
 on:
   push:
+    # Only run for well-formed version tags. A malformed tag such as "v.1.5.0"
+    # would otherwise start a run that goreleaser aborts as invalid semver.
+    # This trigger covers tags pushed by a user (e.g. `make release`); the
+    # Release workflow releases its own tag inline instead.
     tags:
-      - "*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,3 +29,22 @@ jobs:
         run: |
           git tag "v${{ steps.version.outputs.version }}"
           git push origin "v${{ steps.version.outputs.version }}"
+
+      # GoReleaser runs in this same job rather than relying on the goreleaser
+      # workflow's `push: tags` trigger: a tag pushed with the default
+      # GITHUB_TOKEN does not start other workflow runs, so the tag push above
+      # would never kick off a separate release. Running it here releases the
+      # tag we just created.
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The `v1.5.0` tag was created by the **Release** workflow, but **goreleaser never ran** and no release was published.

Root cause: a tag pushed with the default `GITHUB_TOKEN` **does not start other workflow runs** (GitHub's recursion guard). The Release workflow (`workflow_dispatch`) pushes the tag with `GITHUB_TOKEN`, so the separate `goreleaser` workflow (`on: push: tags`) was never triggered.

The earlier releases (v1.4.0 etc.) worked only because their tags were pushed by a user, not the workflow. This was the first use of the new Release workflow, which exposed the gap.

## Fix

- **Run GoReleaser inline in the Release job**, right after it creates and pushes the tag. Same run → no cross-workflow trigger needed → the dispatch flow publishes end to end.
- **Restrict the goreleaser workflow's tag trigger** from `"*"` to `v[0-9]+.[0-9]+.[0-9]+`, so a malformed tag like `v.1.5.0` no longer starts a run that goreleaser immediately aborts. That trigger still covers user-pushed tags (e.g. `make release`).

No new secrets required.

## Release v1.5.0 after this merges

The orphan `v1.5.0` tag (created by the earlier run, never released) will be deleted so the Release workflow can recreate it, then the workflow is run to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)