### PR TITLE
Fix spurious PCR-PTS gap for the final PES before EOF

### DIFF
--- a/tsparser/pes.go
+++ b/tsparser/pes.go
@@ -374,28 +374,48 @@ func (p *Pes) Parse() error {
 
 // DumpTimestamp dump PTS and DTS
 func (p *Pes) DumpTimestamp() float64 {
-	var pcrDelay float64
-	if p.ptsDtsFlags == 2 {
-		if p.nextPcrPos != p.prevPcrPos {
-			prevPcr := float64(p.prevPcr) / 300 / 90
-			nextPcr := float64(p.nextPcr) / 300 / 90
-			pcrDelay = float64(p.pts)/90 - (prevPcr + (nextPcr-prevPcr)*(float64(p.pos-p.prevPcrPos)/float64(p.nextPcrPos-p.prevPcrPos)))
-			fmt.Printf("0x%08x PTS: 0x%08x[%012fms] (pid:0x%02x) (delay:%fms)\n", p.pos, p.pts, float64(p.pts)/90, p.pid, pcrDelay)
-		} else {
-			fmt.Printf("0x%08x PTS: 0x%08x[%012fms] (pid:0x%02x)\n", p.pos, p.pts, float64(p.pts)/90, p.pid)
-		}
+	switch p.ptsDtsFlags {
+	case 2:
+		return p.dumpTimestamp("PTS", p.pts)
+	case 3:
+		// ptsDtsFlags == 3 carries both PTS and DTS; the end-to-end delay is
+		// measured against the DTS (when the access unit is decoded).
+		return p.dumpTimestamp("DTS", p.dts)
 	}
-	if p.ptsDtsFlags == 3 {
-		if p.nextPcrPos != p.prevPcrPos {
-			prevPcr := float64(p.prevPcr) / 300 / 90
-			nextPcr := float64(p.nextPcr) / 300 / 90
-			pcrDelay = float64(p.dts)/90 - (prevPcr + (nextPcr-prevPcr)*(float64(p.pos-p.prevPcrPos)/float64(p.nextPcrPos-p.prevPcrPos)))
-			fmt.Printf("0x%08x DTS: 0x%08x[%012fms] (pid:0x%02x) (delay:%fms)\n", p.pos, p.dts, float64(p.dts)/90, p.pid, pcrDelay)
-		} else {
-			fmt.Printf("0x%08x DTS: 0x%08x[%012fms] (pid:0x%02x)\n", p.pos, p.dts, float64(p.dts)/90, p.pid)
-		}
+	return 0
+}
+
+// dumpTimestamp prints one PTS/DTS line and returns the PCR-to-timestamp delay
+// (the end-to-end buffering delay) in milliseconds.
+func (p *Pes) dumpTimestamp(label string, stamp uint64) float64 {
+	stampMs := float64(stamp) / 90
+	refPcr, ok := p.referencePcrMs()
+	if !ok {
+		fmt.Printf("0x%08x %s: 0x%08x[%012fms] (pid:0x%02x)\n", p.pos, label, stamp, stampMs, p.pid)
+		return 0
 	}
+	pcrDelay := stampMs - refPcr
+	fmt.Printf("0x%08x %s: 0x%08x[%012fms] (pid:0x%02x) (delay:%fms)\n", p.pos, label, stamp, stampMs, p.pid, pcrDelay)
 	return pcrDelay
+}
+
+// referencePcrMs returns the reference PCR (in milliseconds) at this PES's byte
+// position. When a following PCR was captured during the PES, the value is
+// interpolated between the surrounding PCRs by byte position for a tighter
+// estimate. When no following PCR exists (e.g. the final PES before EOF), it
+// falls back to the most recent PCR — interpolating against an unset (zero)
+// nextPcr would otherwise produce a wildly wrong delay. The bool is false when
+// there is no preceding PCR to reference at all.
+func (p *Pes) referencePcrMs() (float64, bool) {
+	if p.prevPcr == 0 {
+		return 0, false
+	}
+	prevPcr := float64(p.prevPcr) / 300 / 90
+	if p.nextPcr > p.prevPcr && p.nextPcrPos > p.prevPcrPos {
+		nextPcr := float64(p.nextPcr) / 300 / 90
+		return prevPcr + (nextPcr-prevPcr)*(float64(p.pos-p.prevPcrPos)/float64(p.nextPcrPos-p.prevPcrPos)), true
+	}
+	return prevPcr, true
 }
 
 // Dump PES header detail.

--- a/tsparser/pes_test.go
+++ b/tsparser/pes_test.go
@@ -1,6 +1,7 @@
 package tsparser
 
 import (
+	"math"
 	"reflect"
 	"testing"
 )
@@ -421,6 +422,46 @@ func TestPesDumpTimestampPtsDtsWithPcr(t *testing.T) {
 		t.Fatalf("Parse error: %s", err)
 	}
 	pes2.DumpTimestamp()
+}
+
+// TestPesDumpTimestampNoFollowingPcr guards the fix for a spurious PCR-PTS gap:
+// when a PES (e.g. the final one before EOF) has no following PCR, nextPcr stays
+// zero. The delay must fall back to the most recent PCR rather than interpolate
+// against the unset (zero) nextPcr, which used to yield a wildly wrong value.
+func TestPesDumpTimestampNoFollowingPcr(t *testing.T) {
+	// PTS=90000 (1000ms). prevPcr=24300000 (900ms), no following PCR.
+	data := []byte{
+		0x00, 0x00, 0x01, 0xE0, 0x00, 0x00, 0x80, 0x80, 0x05,
+		0x21, 0x00, 0x05, 0xBF, 0x21,
+	}
+	pes := NewPes()
+	pes.Append(data)
+	pes.prevPcr = 24300000
+	pes.prevPcrPos = 500
+	pes.nextPcr = 0 // no following PCR captured
+	pes.nextPcrPos = 0
+	pes.pos = 600
+	if err := pes.Parse(); err != nil {
+		t.Fatalf("Parse error: %s", err)
+	}
+	got := pes.DumpTimestamp()
+	if math.Abs(got-100.0) > 1e-6 {
+		t.Errorf("delay: expected fallback to prevPcr (100ms), got %fms", got)
+	}
+}
+
+// TestPesDumpTimestampNoPtsDts covers a PES that carries neither PTS nor DTS.
+func TestPesDumpTimestampNoPtsDts(t *testing.T) {
+	// ptsDtsFlags=0, pes_header_data_length=0.
+	data := []byte{0x00, 0x00, 0x01, 0xE0, 0x00, 0x00, 0x80, 0x00, 0x00}
+	pes := NewPes()
+	pes.Append(data)
+	if err := pes.Parse(); err != nil {
+		t.Fatalf("Parse error: %s", err)
+	}
+	if got := pes.DumpTimestamp(); got != 0 {
+		t.Errorf("delay: expected 0 for a PES without PTS/DTS, got %fms", got)
+	}
 }
 
 func TestPesParseErrors(t *testing.T) {


### PR DESCRIPTION
## Problem

`--dump-timestamp` reported a wildly inflated **PCR-PTS max gap** on some streams. On `testdata/isdbt188.ts` it printed `5878 ms`, even though every individual PES delay was ~25–370 ms.

## Root cause

`Pes.DumpTimestamp()` estimates the reference PCR at a PES's byte position by interpolating between the PCR captured when the PES started (`prevPcr`) and the next PCR seen during the PES (`nextPcr`). The guard only checked that the two PCR **byte positions** differed:

```go
if p.nextPcrPos != p.prevPcrPos { /* interpolate */ }
```

For the **final PES before EOF**, no following PCR is ever captured, so `nextPcr`/`nextPcrPos` stay at their zero value. `prevPcrPos` is large and `nextPcrPos` is `0`, so the positions "differ" and the code interpolates against `nextPcr = 0`, yielding a garbage delay that then dominated the max-gap summary.

## Fix

Fall back to the most recent PCR when no valid following PCR exists, and only interpolate when `nextPcr` is genuinely set (`nextPcr > prevPcr && nextPcrPos > prevPcrPos`). Refactored the duplicated PTS/DTS branches into a small helper.

## Verification

Cross-checked the same file against two independent references:

| Metric | before | after | Comcast/gots | TSDuck `pcrextract` |
|---|---|---|---|---|
| Max PCR interval | 37.300 ms | 37.300 ms | 37.300 ms | 37.30 ms |
| PCR-PTS max gap | **5878 ms** | **336 ms** | 369 ms* | 469 ms** |

\* gots, same DTS-based definition, no interpolation. \*\* PTS-based. The remaining ~33 ms vs gots is our forward interpolation of the reference PCR to the exact PES byte position (about one PCR interval), not an error.

## Tests

- `TestPesDumpTimestampNoFollowingPcr` — regression guard: a PES with an unset `nextPcr` must fall back to `prevPcr` (asserts a finite 100 ms delay, not a garbage value).
- `TestPesDumpTimestampNoPtsDts` — a PES carrying neither PTS nor DTS returns 0.
- `tsparser` and `bitbuffer` remain at 100% statement coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)