### PR TITLE
docs: add "Mentioned in Awesome Go" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/small-teton/mpeg-ts-analyzer/v2.svg)](https://pkg.go.dev/github.com/small-teton/mpeg-ts-analyzer/v2)
 [![Release](https://img.shields.io/github/v/release/small-teton/mpeg-ts-analyzer)](https://github.com/small-teton/mpeg-ts-analyzer/releases)
 ![License](https://img.shields.io/github/license/small-teton/mpeg-ts-analyzer)
+[![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)
 
 mpeg-ts-analyzer is an MPEG-2 Transport Stream analyzer (ISO/IEC 13818-1).
 


### PR DESCRIPTION
## Summary

mpeg-ts-analyzer was accepted into [awesome-go](https://github.com/avelino/awesome-go) (Video category, avelino/awesome-go#6584). Adds the standard "Mentioned in Awesome Go" badge to the README header.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)