### PR TITLE
feat: detect PTS/DTS continuity and monotonicity anomalies

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -15,6 +15,27 @@ PMT : Program Info : elementary_PID     : 0x100, stream_type : 0x02 (13818-2 vid
 PMT : Program Info : elementary_PID     : 0x101, stream_type : 0x03 (11172 audio)
 ```
 
+## Timestamp anomaly report (always on)
+
+PTS/DTS anomalies are checked on every run, with no flag. Nothing is printed for
+a healthy stream; when problems are found, a report is appended at the end:
+
+```
+-----------------------------
+Timestamp Anomaly Report:
+  PID 0x0100: PTS went backward at 0x00123457 (2001.000ms) after 0x00123456 (2041.000ms)
+  PID 0x0100: PTS jumped forward 5.3s at 0x00234567 (7374.333ms) after 0x00123458 (2041.000ms), expected ~40ms
+  PID 0x0101: PTS wrapped around (33-bit counter overflow) at 0x00345679
+  PID 0x0102: DTS is later than PTS in the access unit at 0x00400000 (DTS 22.222ms > PTS 11.111ms)
+```
+
+Reading the output:
+
+- Each line is one PID and the first place a problem was seen; repeats of the
+  same problem on the same PID are collapsed with `(and N more)`.
+- Checks run on the decode timeline (DTS when present, otherwise PTS), so a
+  B-frame stream — whose PTS legitimately reorders — is not falsely flagged.
+
 ## Dump TS header
 
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It parses TS packets and checks whether the stream conforms to the following req
 
 - **Max PCR interval** should be no greater than 100 ms (ISO/IEC 13818-1, Section 2.7.2)
 - **PCR-PTS max gap** (end-to-end delay) should be no greater than 1000 ms
+- **PTS/DTS anomalies** — timestamps going backward, 33-bit wraparound, large forward jumps (splicing/ad insertion), or DTS later than PTS — are detected and reported (always on; silent when the stream is healthy)
 
 In addition, it can dump various MPEG-2 TS internal structures for stream investigation:
 

--- a/tsparser/mpeg_packet.go
+++ b/tsparser/mpeg_packet.go
@@ -95,6 +95,15 @@ func BufferPes(reader io.Reader, pos *int64, pmtPid, pcrPid uint16, programInfos
 	if options.DumpBitrate {
 		bitrate = NewBitrateStats(options.Program, pmtPid, pcrPid, programInfos)
 	}
+	// PTS/DTS anomaly detection is always on; it prints only when a problem is
+	// found, so a healthy stream stays quiet. Only a cleanly parsed PES is
+	// checked — a partially parsed header would carry garbage timestamps.
+	anomaly := NewTimestampAnomaly()
+	checkAnomaly := func(perr error, pes *Pes) {
+		if perr == nil {
+			anomaly.Check(pes)
+		}
+	}
 	tsPacket := NewTsPacket()
 
 	for endOffset <= 0 || *pos+int64(packetSize) <= endOffset {
@@ -158,7 +167,7 @@ func BufferPes(reader io.Reader, pos *int64, pmtPid, pcrPid uint16, programInfos
 
 		if tsPacket.PayloadUnitStartIndicator() {
 			if pes != nil {
-				_ = pes.Parse()
+				perr := pes.Parse()
 				if options.DumpTimestamp {
 					pcrDelay := pes.DumpTimestamp()
 					maxDelay = math.Max(maxDelay, pcrDelay)
@@ -166,6 +175,7 @@ func BufferPes(reader io.Reader, pos *int64, pmtPid, pcrPid uint16, programInfos
 				if options.DumpPesHeader {
 					pes.DumpHeader()
 				}
+				checkAnomaly(perr, pes)
 			} else {
 				pes = NewPes()
 				pesMap[pid] = pes
@@ -200,13 +210,14 @@ func BufferPes(reader io.Reader, pos *int64, pmtPid, pcrPid uint16, programInfos
 		if pes == nil || len(pes.buf) == 0 {
 			continue
 		}
-		_ = pes.Parse()
+		perr := pes.Parse()
 		if options.DumpTimestamp {
 			maxDelay = math.Max(maxDelay, pes.DumpTimestamp())
 		}
 		if options.DumpPesHeader {
 			pes.DumpHeader()
 		}
+		checkAnomaly(perr, pes)
 	}
 
 	if options.DumpTimestamp {
@@ -220,6 +231,7 @@ func BufferPes(reader io.Reader, pos *int64, pmtPid, pcrPid uint16, programInfos
 	if bitrate != nil {
 		bitrate.Dump()
 	}
+	anomaly.Dump()
 
 	return nil
 }

--- a/tsparser/mpeg_packet_test.go
+++ b/tsparser/mpeg_packet_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/small-teton/mpeg-ts-analyzer/v2/options"
@@ -446,5 +447,142 @@ func TestBufferPesFinalPesMultiPid(t *testing.T) {
 	var opts options.Options
 	if err := BufferPes(r, &pos, 0x30, 0x31, programInfos, opts, 188, 0); err != nil {
 		t.Errorf("unexpected error: %s", err)
+	}
+}
+
+// buildPesTsPacket builds a 188-byte TS packet whose payload IS a PES (start
+// code at byte 4). Unlike buildTsPacket, it does not prepend a PSI
+// pointer_field, so the PES actually parses.
+func buildPesTsPacket(pid uint16, cc uint8, payload []byte) []byte {
+	pkt := make([]byte, 188)
+	pkt[0] = 0x47
+	pkt[1] = 0x40 | uint8((pid>>8)&0x1F) // payload_unit_start_indicator = 1
+	pkt[2] = uint8(pid & 0xFF)
+	pkt[3] = 0x10 | (cc & 0x0F) // payload only
+	copy(pkt[4:], payload)
+	for i := 4 + len(payload); i < 188; i++ {
+		pkt[i] = 0xFF
+	}
+	return pkt
+}
+
+func TestBufferPesAnomalyValidPesChecked(t *testing.T) {
+	// A cleanly parsed PES reaches the anomaly check (a single access unit just
+	// seeds the per-PID baseline). Exercises the parse-succeeded path.
+	f, err := os.CreateTemp("", "pesvalid*.ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(f.Name()) }()
+
+	programInfos := []ProgramInfo{{streamType: 0x1B, elementaryPid: 0x31}}
+	// A valid PES header (ptsDtsFlags=3: PTS and DTS present).
+	validPes := []byte{
+		0x00, 0x00, 0x01, 0xE0, 0x00, 0x00, 0x84, 0xC0, 0x0A, 0x31, 0x00, 0x01, 0xC7, 0x3F, 0x11, 0x00,
+		0x01, 0xAF, 0xC9, 0x00,
+	}
+
+	_, _ = f.Write(buildPesTsPacket(0x0031, 1, validPes))
+	_ = f.Close()
+
+	f2, err := os.Open(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f2.Close() }()
+
+	var pos int64
+	var opts options.Options
+	out := captureStdout(t, func() {
+		if err := BufferPes(f2, &pos, 0x0030, 0x0031, programInfos, opts, 188, 0); err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+	})
+	if strings.Contains(out, "Timestamp Anomaly Report:") {
+		t.Errorf("no anomaly should be reported here:\n%s", out)
+	}
+}
+
+// encodePtsOnlyPes builds a PES header carrying only a PTS (ptsDtsFlags=2) with
+// the given 90 kHz value, for end-to-end anomaly tests.
+func encodePtsOnlyPes(pts uint64) []byte {
+	return []byte{
+		0x00, 0x00, 0x01, 0xE0, // start code + video stream_id
+		0x00, 0x00, // pes_packet_length
+		0x80, // '10' marker
+		0x80, // ptsDtsFlags=10 (PTS only)
+		0x05, // pes_header_data_length
+		0x21 | byte((pts>>29)&0x0E),
+		byte((pts >> 22) & 0xFF),
+		0x01 | byte((pts>>14)&0xFE),
+		byte((pts >> 7) & 0xFF),
+		0x01 | byte((pts<<1)&0xFE),
+	}
+}
+
+func TestBufferPesEmitsAnomaly(t *testing.T) {
+	// Two PES with a decreasing PTS must produce a "went backward" report.
+	f, err := os.CreateTemp("", "pesanom*.ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(f.Name()) }()
+
+	programInfos := []ProgramInfo{{streamType: 0x1B, elementaryPid: 0x31}}
+	_, _ = f.Write(buildPesTsPacket(0x0031, 1, encodePtsOnlyPes(90000))) // 1000 ms
+	_, _ = f.Write(buildPesTsPacket(0x0031, 2, encodePtsOnlyPes(45000))) // 500 ms (backward)
+	_ = f.Close()
+
+	f2, err := os.Open(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f2.Close() }()
+
+	var pos int64
+	var opts options.Options
+	out := captureStdout(t, func() {
+		if err := BufferPes(f2, &pos, 0x0030, 0x0031, programInfos, opts, 188, 0); err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+	})
+	if !strings.Contains(out, "Timestamp Anomaly Report:") || !strings.Contains(out, "PTS went backward") {
+		t.Errorf("expected a backward-PTS anomaly report, got:\n%s", out)
+	}
+}
+
+func TestBufferPesAnomalyParseErrorSkipped(t *testing.T) {
+	// A completed PES whose payload has an invalid packet_start_code_prefix makes
+	// pes.Parse() fail; the timestamp anomaly check must be skipped (garbage
+	// header) and BufferPes must still return nil.
+	f, err := os.CreateTemp("", "pesparseerr*.ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(f.Name()) }()
+
+	programInfos := []ProgramInfo{{streamType: 0x1B, elementaryPid: 0x31}}
+	badPayload := []byte{0xFF, 0xFF, 0xFF, 0xE0, 0x00, 0x00} // start code != 0x000001
+
+	_, _ = f.Write(buildPcrPacket(0x0031, 13500))
+	_, _ = f.Write(buildTsPacket(0x0031, true, 1, badPayload)) // first PES (bad)
+	_, _ = f.Write(buildTsPacket(0x0031, true, 2, badPayload)) // second PUSI parses the first PES -> error
+	_ = f.Close()
+
+	f2, err := os.Open(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f2.Close() }()
+
+	var pos int64
+	var opts options.Options
+	out := captureStdout(t, func() {
+		if err := BufferPes(f2, &pos, 0x0030, 0x0031, programInfos, opts, 188, 0); err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+	})
+	if strings.Contains(out, "Timestamp Anomaly Report:") {
+		t.Errorf("no anomaly should be reported here:\n%s", out)
 	}
 }

--- a/tsparser/timestamp_anomaly.go
+++ b/tsparser/timestamp_anomaly.go
@@ -1,0 +1,187 @@
+package tsparser
+
+import "fmt"
+
+// PTS/DTS continuity and monotonicity checks (ISO/IEC 13818-1 §2.4.3.7).
+//
+// Properly advancing PTS/DTS values are essential for smooth playback. This
+// detects the common failure modes — timestamps going backward, 33-bit
+// wraparound, large forward jumps (ad insertion / splicing), and DTS after PTS
+// — that are hard to spot without packet-level inspection.
+//
+// Monotonicity is judged on the *decode* timeline: DTS when present, otherwise
+// PTS (which equals DTS when no DTS is signalled). Presentation-order PTS
+// legitimately steps backward between B-frames, so it is not a reliable
+// monotonic axis; the decode timeline is.
+//
+// The check is always on; a healthy stream produces no output. Repeated
+// occurrences of the same problem on the same PID are collapsed to one line
+// (the first occurrence, plus a count of the rest), so a badly broken stream
+// that trips on every access unit stays readable.
+
+const (
+	// ptsClockHz is the 90 kHz clock PTS/DTS are expressed in.
+	ptsClockHz = 90000
+	// ptsWrap is the 33-bit PTS/DTS wrap period (~26.5 hours in ticks).
+	ptsWrap = int64(1) << 33
+	// ptsHalfWrap separates a genuine backward step from a 33-bit counter
+	// wraparound. A raw drop larger than half the range is a forward wrap (the
+	// counter overflowed 2^33 -> 0); a raw *rise* larger than half the range is a
+	// small backward step whose unsigned value wrapped up past zero.
+	ptsHalfWrap = ptsWrap / 2
+	// tsGapRatio: a forward decode step at least this many times the stream's
+	// smallest observed step (its frame interval) is a candidate gap.
+	tsGapRatio = 5
+	// tsGapMinTicks: ignore gaps whose excess over the frame interval is below
+	// this (0.5 s) so a variable GOP or a single dropped frame is not reported.
+	tsGapMinTicks = ptsClockHz / 2
+)
+
+// anomalyKind identifies a category of PTS/DTS anomaly, used only to group
+// repeated occurrences on the same PID.
+type anomalyKind int
+
+const (
+	kindBackward anomalyKind = iota
+	kindWraparound
+	kindGap
+	kindDtsAfterPts
+)
+
+// tsState tracks the decode timeline of one PID.
+type tsState struct {
+	have    bool
+	last    uint64 // last decode timestamp (DTS, or PTS when no DTS)
+	lastPos int64  // byte position of that timestamp's PES
+	minStep int64  // smallest positive step seen (~frame interval), 0 until known
+}
+
+type anomalyKey struct {
+	pid  uint16
+	kind anomalyKind
+}
+
+// TimestampAnomaly collects PTS/DTS anomalies per PID during a scan and prints
+// them at the end.
+type TimestampAnomaly struct {
+	states map[uint16]*tsState
+	order  []anomalyKey          // (PID, kind) in first-seen order
+	first  map[anomalyKey]string // first occurrence's message
+	counts map[anomalyKey]int    // total occurrences
+}
+
+// NewTimestampAnomaly creates an empty collector.
+func NewTimestampAnomaly() *TimestampAnomaly {
+	return &TimestampAnomaly{
+		states: make(map[uint16]*tsState),
+		first:  make(map[anomalyKey]string),
+		counts: make(map[anomalyKey]int),
+	}
+}
+
+// Check examines one successfully parsed PES that carries PTS/DTS.
+func (a *TimestampAnomaly) Check(p *Pes) {
+	if p.ptsDtsFlags != 2 && p.ptsDtsFlags != 3 {
+		return
+	}
+
+	// DTS must be at or before PTS within one access unit (only meaningful when
+	// both are present). signedDelta folds the 33-bit wrap so a stamp straddling
+	// the wrap boundary is not misread as a violation.
+	if p.ptsDtsFlags == 3 && signedDelta(p.pts, p.dts) < 0 {
+		a.add(p.pid, kindDtsAfterPts, fmt.Sprintf(
+			"DTS is later than PTS in the access unit at 0x%08x (DTS %s > PTS %s)",
+			p.pos, stampMs(p.dts), stampMs(p.pts)))
+	}
+
+	label, decode := "PTS", p.pts
+	if p.ptsDtsFlags == 3 {
+		label, decode = "DTS", p.dts
+	}
+
+	st := a.states[p.pid]
+	if st == nil {
+		st = &tsState{}
+		a.states[p.pid] = st
+	}
+	if !st.have {
+		st.have, st.last, st.lastPos = true, decode, p.pos
+		return
+	}
+
+	// Raw (unfolded) difference of two values in [0, 2^33), so the result is in
+	// (-2^33, 2^33). A forward counter overflow shows as a near -2^33 drop; a
+	// backward step across zero shows as a near +2^33 rise.
+	raw := int64(decode) - int64(st.last)
+	switch {
+	case raw <= -ptsHalfWrap:
+		a.add(p.pid, kindWraparound, fmt.Sprintf(
+			"%s wrapped around (33-bit counter overflow) at 0x%08x", label, p.pos))
+	case raw < 0 || raw >= ptsHalfWrap:
+		a.add(p.pid, kindBackward, fmt.Sprintf(
+			"%s went backward at 0x%08x (%s) after 0x%08x (%s)",
+			label, p.pos, stampMs(decode), st.lastPos, stampMs(st.last)))
+	default:
+		if st.minStep > 0 && raw > int64(tsGapRatio)*st.minStep && raw-st.minStep > tsGapMinTicks {
+			a.add(p.pid, kindGap, fmt.Sprintf(
+				"%s jumped forward %s at 0x%08x (%s) after 0x%08x (%s), expected ~%s",
+				label, durTicks(raw), p.pos, stampMs(decode), st.lastPos, stampMs(st.last), durTicks(st.minStep)))
+		}
+		if raw > 0 && (st.minStep == 0 || raw < st.minStep) {
+			st.minStep = raw
+		}
+	}
+	st.last, st.lastPos = decode, p.pos
+}
+
+// Dump prints the anomaly report, or nothing when the stream is clean.
+func (a *TimestampAnomaly) Dump() {
+	if len(a.order) == 0 {
+		return
+	}
+	fmt.Println("-----------------------------")
+	fmt.Println("Timestamp Anomaly Report:")
+	for _, k := range a.order {
+		line := fmt.Sprintf("  PID 0x%04x: %s", k.pid, a.first[k])
+		if extra := a.counts[k] - 1; extra > 0 {
+			line += fmt.Sprintf(" (and %d more)", extra)
+		}
+		fmt.Println(line)
+	}
+}
+
+// add records one occurrence; only the first per (PID, kind) keeps its message.
+func (a *TimestampAnomaly) add(pid uint16, kind anomalyKind, msg string) {
+	key := anomalyKey{pid, kind}
+	if a.counts[key] == 0 {
+		a.first[key] = msg
+		a.order = append(a.order, key)
+	}
+	a.counts[key]++
+}
+
+// signedDelta returns (a - b) folded into the 33-bit wrap window
+// [-2^32, 2^32), so a small step reads with its true sign regardless of a wrap
+// between the two values.
+func signedDelta(a, b uint64) int64 {
+	d := (int64(a) - int64(b)) % ptsWrap
+	switch {
+	case d >= ptsHalfWrap:
+		d -= ptsWrap
+	case d < -ptsHalfWrap:
+		d += ptsWrap
+	}
+	return d
+}
+
+// stampMs formats a 90 kHz stamp as milliseconds.
+func stampMs(stamp uint64) string { return fmt.Sprintf("%.3fms", float64(stamp)/90.0) }
+
+// durTicks formats a 90 kHz tick count as a human duration (s for >= 1 s).
+func durTicks(ticks int64) string {
+	ms := float64(ticks) / 90.0
+	if ms >= 1000 {
+		return fmt.Sprintf("%.1fs", ms/1000)
+	}
+	return fmt.Sprintf("%.0fms", ms)
+}

--- a/tsparser/timestamp_anomaly_test.go
+++ b/tsparser/timestamp_anomaly_test.go
@@ -1,0 +1,197 @@
+package tsparser
+
+import (
+	"strings"
+	"testing"
+)
+
+// feed builds a PES carrying the given decode/presentation stamps and runs it
+// through the checker. flags 2 = PTS only, 3 = PTS+DTS.
+func feed(a *TimestampAnomaly, pid uint16, pos int64, flags uint8, pts, dts uint64) {
+	a.Check(&Pes{pid: pid, pos: pos, ptsDtsFlags: flags, pts: pts, dts: dts})
+}
+
+const frame = uint64(3600) // 40 ms at 90 kHz
+
+func TestAnomalyHealthyMonotonicIsQuiet(t *testing.T) {
+	a := NewTimestampAnomaly()
+	for i := uint64(0); i < 5; i++ {
+		feed(a, 0x100, int64(i), 2, i*frame, 0)
+	}
+	if len(a.order) != 0 {
+		t.Errorf("healthy monotonic stream reported anomalies: %v", a.order)
+	}
+}
+
+func TestAnomalyIgnoresPesWithoutTimestamp(t *testing.T) {
+	a := NewTimestampAnomaly()
+	feed(a, 0x100, 0, 0, 0, 0) // ptsDtsFlags 0: no PTS/DTS
+	if len(a.order) != 0 {
+		t.Error("a PES without PTS/DTS must not be checked")
+	}
+}
+
+func TestAnomalyBFrameReorderIsQuiet(t *testing.T) {
+	// Decode order I,P,B: DTS rises monotonically while PTS steps backward at the
+	// B-frame. That is legal — only the decode timeline (DTS) must be monotonic,
+	// and every DTS <= its PTS.
+	a := NewTimestampAnomaly()
+	feed(a, 0x100, 0, 3, 1000, 1000)
+	feed(a, 0x100, 1, 3, 1400, 1100) // P: presented later
+	feed(a, 0x100, 2, 3, 1200, 1200) // B: PTS goes 1400 -> 1200, DTS 1100 -> 1200
+	if len(a.order) != 0 {
+		t.Errorf("B-frame reorder must not be flagged: %v", a.order)
+	}
+}
+
+func TestAnomalyBackward(t *testing.T) {
+	a := NewTimestampAnomaly()
+	feed(a, 0x100, 0x10, 2, 10000, 0)
+	feed(a, 0x100, 0x20, 2, 9000, 0) // backward
+	if a.counts[anomalyKey{0x100, kindBackward}] != 1 {
+		t.Fatalf("expected one backward anomaly, got %v", a.counts)
+	}
+}
+
+func TestAnomalyBackwardOnDtsTimeline(t *testing.T) {
+	a := NewTimestampAnomaly()
+	feed(a, 0x100, 0x10, 3, 5000, 5000)
+	feed(a, 0x100, 0x20, 3, 4000, 4000) // DTS backward
+	if a.counts[anomalyKey{0x100, kindBackward}] != 1 {
+		t.Fatalf("expected DTS backward anomaly, got %v", a.counts)
+	}
+}
+
+func TestAnomalyWraparound(t *testing.T) {
+	a := NewTimestampAnomaly()
+	feed(a, 0x100, 0x10, 2, uint64(ptsWrap)-frame, 0) // just below the 33-bit max
+	feed(a, 0x100, 0x20, 2, frame, 0)                 // wrapped to near zero
+	if a.counts[anomalyKey{0x100, kindWraparound}] != 1 {
+		t.Fatalf("expected wraparound, got %v", a.counts)
+	}
+}
+
+func TestAnomalyGap(t *testing.T) {
+	a := NewTimestampAnomaly()
+	feed(a, 0x100, 0x10, 2, 0, 0)
+	feed(a, 0x100, 0x20, 2, frame, 0)        // establishes the frame interval
+	feed(a, 0x100, 0x30, 2, frame+480000, 0) // ~5.3 s jump
+	if a.counts[anomalyKey{0x100, kindGap}] != 1 {
+		t.Fatalf("expected a gap, got %v", a.counts)
+	}
+}
+
+func TestAnomalyGapSubSecondUsesMs(t *testing.T) {
+	// A ~0.7 s gap exercises durTicks' millisecond branch.
+	a := NewTimestampAnomaly()
+	feed(a, 0x100, 0x10, 2, 0, 0)
+	feed(a, 0x100, 0x20, 2, frame, 0)
+	feed(a, 0x100, 0x30, 2, frame+63000, 0) // 700 ms
+	if a.counts[anomalyKey{0x100, kindGap}] != 1 {
+		t.Fatalf("expected a sub-second gap, got %v", a.counts)
+	}
+}
+
+func TestAnomalyModerateJumpIsNotAGap(t *testing.T) {
+	// A doubled interval (one dropped frame) is below both gap thresholds.
+	a := NewTimestampAnomaly()
+	feed(a, 0x100, 0x10, 2, 0, 0)
+	feed(a, 0x100, 0x20, 2, frame, 0)
+	feed(a, 0x100, 0x30, 2, frame+2*frame, 0)
+	if len(a.order) != 0 {
+		t.Errorf("a doubled frame interval must not be a gap: %v", a.order)
+	}
+}
+
+func TestAnomalyBackwardAcrossZeroBoundary(t *testing.T) {
+	// A small backward step when the timestamp is near zero wraps the unsigned
+	// value up past the max; it must be read as backward, not a huge gap.
+	a := NewTimestampAnomaly()
+	feed(a, 0x100, 0x10, 2, 100, 0)
+	feed(a, 0x100, 0x20, 2, uint64(ptsWrap)-100, 0) // 100 - 200 -> wraps up
+	if a.counts[anomalyKey{0x100, kindBackward}] != 1 {
+		t.Fatalf("expected backward across the zero boundary, got %v", a.counts)
+	}
+	if a.counts[anomalyKey{0x100, kindGap}] != 0 {
+		t.Fatalf("must not be reported as a gap, got %v", a.counts)
+	}
+}
+
+func TestAnomalyMixedPtsOnlyAndPtsDts(t *testing.T) {
+	// A PID that alternates PTS-only and PTS+DTS access units stays on one decode
+	// timeline (DTS when present, else PTS) and is not falsely flagged.
+	a := NewTimestampAnomaly()
+	feed(a, 0x100, 0, 3, 1000, 1000) // decode 1000
+	feed(a, 0x100, 1, 2, 1100, 0)    // decode 1100 (PTS==DTS)
+	feed(a, 0x100, 2, 3, 1300, 1200) // decode 1200
+	if len(a.order) != 0 {
+		t.Errorf("mixed PTS-only / PTS+DTS must not be flagged: %v", a.order)
+	}
+}
+
+func TestAnomalyDtsAfterPts(t *testing.T) {
+	a := NewTimestampAnomaly()
+	feed(a, 0x100, 0x10, 3, 1000, 2000) // DTS 2000 > PTS 1000
+	if a.counts[anomalyKey{0x100, kindDtsAfterPts}] != 1 {
+		t.Fatalf("expected DTS-after-PTS, got %v", a.counts)
+	}
+}
+
+func TestAnomalyAggregatesRepeats(t *testing.T) {
+	a := NewTimestampAnomaly()
+	feed(a, 0x100, 0, 2, 10000, 0)
+	feed(a, 0x100, 1, 2, 9000, 0) // backward #1
+	feed(a, 0x100, 2, 2, 8000, 0) // backward #2
+	feed(a, 0x100, 3, 2, 7000, 0) // backward #3
+	if got := a.counts[anomalyKey{0x100, kindBackward}]; got != 3 {
+		t.Fatalf("expected 3 backward occurrences, got %d", got)
+	}
+	if len(a.order) != 1 {
+		t.Fatalf("repeats on one PID+kind must collapse to one report entry, got %d", len(a.order))
+	}
+}
+
+func TestAnomalyDumpEmpty(t *testing.T) {
+	// Clean stream: Dump prints nothing and does not panic.
+	NewTimestampAnomaly().Dump()
+}
+
+func TestAnomalyDumpWithFindings(t *testing.T) {
+	a := NewTimestampAnomaly()
+	feed(a, 0x100, 0, 2, 10000, 0)
+	feed(a, 0x100, 1, 2, 9000, 0) // backward #1
+	feed(a, 0x100, 2, 2, 8000, 0) // backward #2 (collapsed)
+	feed(a, 0x101, 0, 3, 1000, 2000)
+
+	out := captureStdout(t, a.Dump)
+	if !strings.Contains(out, "Timestamp Anomaly Report:") {
+		t.Errorf("missing report header:\n%s", out)
+	}
+	// Two backward occurrences on 0x0100 collapse to one line with a count.
+	if !strings.Contains(out, "(and 1 more)") {
+		t.Errorf("repeated anomaly not collapsed with a count:\n%s", out)
+	}
+	// A single occurrence on 0x0101 has no count suffix.
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "0x0101") && strings.Contains(line, "and ") {
+			t.Errorf("single occurrence should not carry a count: %q", line)
+		}
+	}
+}
+
+func TestSignedDelta(t *testing.T) {
+	cases := []struct {
+		a, b uint64
+		want int64
+	}{
+		{100, 50, 50},                           // normal forward
+		{50, 100, -50},                          // normal backward
+		{frame, uint64(ptsWrap) - frame, 7200},  // small forward across wrap (2*frame)
+		{uint64(ptsWrap) - frame, frame, -7200}, // small backward across wrap
+	}
+	for _, c := range cases {
+		if got := signedDelta(c.a, c.b); got != c.want {
+			t.Errorf("signedDelta(%d, %d) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #22.

## What

Adds always-on PTS/DTS continuity and monotonicity checks. During the scan each
parsed PES is checked; a report is printed at the end **only when problems are
found**, so a healthy stream stays silent.

Detected:

- timestamp going backward (non-monotonic)
- 33-bit counter wraparound (~26.5 h)
- large forward jump / gap (ad insertion, splicing)
- DTS later than PTS within one access unit

```
-----------------------------
Timestamp Anomaly Report:
  PID 0x0100: PTS went backward at 0x00123457 (2001.000ms) after 0x00123456 (2041.000ms)
  PID 0x0100: PTS jumped forward 5.3s at 0x00234567 (7374.333ms) after 0x00123458 (2041.000ms), expected ~40ms
  PID 0x0101: PTS wrapped around (33-bit counter overflow) at 0x00345679
  PID 0x0102: DTS is later than PTS in the access unit at 0x00400000 (DTS 22.222ms > PTS 11.111ms)
```

## How

- **Decode timeline.** Monotonicity is judged on DTS when present, otherwise PTS
  (which equals DTS when no DTS is signalled). Presentation-order PTS
  legitimately reorders across B-frames, so it is not a reliable monotonic axis;
  the decode timeline is. Mixed PTS-only / PTS+DTS access units stay on one axis.
- **Wrap vs backward.** A raw drop larger than half the 33-bit range is a forward
  counter overflow (wraparound); a smaller drop — or a rise larger than half the
  range, i.e. a small backward step that crossed zero — is reported as backward.
- **Gaps** are flagged when a forward step exceeds both 5× the PID's smallest
  observed step (its frame interval) and 0.5 s of excess, so a variable GOP or a
  single dropped frame is not noise.
- **Bounded output.** Repeats of the same problem on the same PID collapse to one
  line (first occurrence + `(and N more)`). Each two-packet finding names the
  offending position, the preceding position, and both timestamp values.
- Wired into `BufferPes`; only a cleanly parsed PES is checked (a partial parse
  would carry garbage timestamps).

## Validation

Cross-checked against **ffprobe** as an independent ground truth (a healthy
sample has no anomalies to compare, so a known anomaly was injected by
concatenating a sample with itself, which resets PTS/DTS at the join):

- **True positive:** on the doubled stream this tool reports
  `DTS went backward at 0x0004c310 (1400.000ms) after 0x0004a66c (6360.000ms)`
  and the audio equivalent. ffprobe's per-packet `pos` + `pts_time`/`dts_time`
  report the same backward transitions at the **same byte positions**
  (`0x0004c310`, `0x0004c9ac`) and the same values — an exact match on both
  position and time.
- **No false positives:** on the healthy sample both this tool and ffprobe report
  zero backward transitions.
- **Easier localization (the point of this feature).** ffprobe can surface the
  same transitions, but only by dumping every packet and post-processing to find
  the offender. This tool reports the **first offending position directly** as
  `at 0x...` (byte offset) with the before/after values, so you jump straight to
  it — no full-stream dump, no scripting.

(TSDuck `tsanalyze` reports CC discontinuities and PTS/DTS counts but not
PTS/DTS monotonicity violations, which is exactly the gap this feature fills;
ffprobe's per-packet dump was the appropriate reference.)

**Attached to this PR:** the cross-check script (`verify_pts_anomaly.py`) and an
anomalous sample. The sample is a healthy sample concatenated with itself, which
resets PTS/DTS at the join — reproduce with `cat sample.ts sample.ts > anomaly.ts`
and run `python3 verify_pts_anomaly.py anomaly.ts`.

## Tests

- `tsparser/timestamp_anomaly_test.go`: backward, wraparound, gap, DTS-after-PTS,
  B-frame reorder (must stay quiet), mixed PTS-only/PTS+DTS, zero-boundary
  backward, aggregation / `(and N more)`, and `signedDelta` folding.
- `tsparser/mpeg_packet_test.go`: end-to-end through `BufferPes` — a real
  backward-PTS anomaly is emitted, a parse-failing PES is skipped, a clean PES is
  checked.
- `tsparser` stays at **100% coverage**; `go vet` and `golangci-lint` clean.

[verify_pts_anomaly.py](https://github.com/user-attachments/files/31213108/verify_pts_anomaly.py)
[sample_188byte_pts_anomaly_concat.ts](https://github.com/user-attachments/files/31213100/sample_188byte_pts_anomaly_concat.ts)


🤖 Generated with [Claude Code](https://claude.com/claude-code)