### PR TITLE
Add per-PID continuity counter error summary

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -13,7 +13,29 @@ Detected PAT: 1 program(s)
 Detected PMT
 PMT : Program Info : elementary_PID     : 0x100, stream_type : 0x02 (13818-2 video or 11172-2 constrained parameter video stream)
 PMT : Program Info : elementary_PID     : 0x101, stream_type : 0x03 (11172 audio)
+-----------------------------
+Continuity Counter: no errors detected
 ```
+
+## Continuity counter summary (always on)
+
+Every continuity counter violation is still printed inline at the byte position
+where it is detected. A per-PID summary is always appended at the end so errors
+remain visible even when the analysis produces a large amount of output:
+
+```
+packet loss. : pid=0x100. count=0x5, pos=0x00123456
+packet loss. : pid=0x100. count=0x9, pos=0x00234567
+packet loss. : pid=0x101. count=0x3, pos=0x00345678
+-----------------------------
+Continuity Counter Error Summary:
+  PID 0x0100 (video) : 2 errors
+  PID 0x0101 (audio) : 1 error
+  Total              : 3 errors in 2 PIDs
+```
+
+The count is the number of violations reported by the existing PES continuity
+check. It does not estimate how many transport packets were lost.
 
 ## Timestamp anomaly report (always on)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In addition, it can dump various MPEG-2 TS internal structures for stream invest
 - PMT ES info descriptors (ISO 639 language, registration, AVC/HEVC video, AAC audio, teletext, DVB subtitling)
 - PES header with PTS/DTS timestamps
 - PCR jitter analysis (per-interval deviation from the expected PCR)
-- `continuity_counter` validation
+- `continuity_counter` validation with an always-on per-PID error summary
 
 Both 188-byte TS packets and 192-byte M2TS packets (BDAV format with TP_extra_header) are supported. The packet size is auto-detected from the stream.
 

--- a/tsparser/continuity_counter.go
+++ b/tsparser/continuity_counter.go
@@ -1,0 +1,82 @@
+package tsparser
+
+import (
+	"fmt"
+	"sort"
+)
+
+// continuityCounterSummary collects the continuity_counter violations already
+// detected while buffering PES packets. It does not change detection or
+// recovery behavior; it only makes the inline warnings visible as an end-of-run
+// summary.
+type continuityCounterSummary struct {
+	counts map[uint16]int
+	labels map[uint16]string
+}
+
+func newContinuityCounterSummary(programInfos []ProgramInfo) *continuityCounterSummary {
+	s := &continuityCounterSummary{
+		counts: make(map[uint16]int),
+		labels: make(map[uint16]string),
+	}
+	for _, info := range programInfos {
+		s.labels[info.elementaryPid] = continuityCounterLabel(info.streamType)
+	}
+	return s
+}
+
+func (s *continuityCounterSummary) Add(pid uint16) { s.counts[pid]++ }
+
+// Dump prints a deterministic per-PID summary. A healthy stream still gets a
+// one-line result because continuity integrity is an always-on health check.
+func (s *continuityCounterSummary) Dump() {
+	fmt.Println("-----------------------------")
+	if len(s.counts) == 0 {
+		fmt.Println("Continuity Counter: no errors detected")
+		return
+	}
+
+	fmt.Println("Continuity Counter Error Summary:")
+	pids := make([]uint16, 0, len(s.counts))
+	for pid := range s.counts {
+		pids = append(pids, pid)
+	}
+	sort.Slice(pids, func(i, j int) bool { return pids[i] < pids[j] })
+
+	var total int
+	for _, pid := range pids {
+		count := s.counts[pid]
+		total += count
+		label := s.labels[pid]
+		if label == "" {
+			label = "unknown"
+		}
+		fmt.Printf("  PID 0x%04x (%s) : %d %s\n", pid, label, count, errorWord(count))
+	}
+	fmt.Printf("  Total              : %d %s in %d %s\n", total, errorWord(total), len(pids), pidWord(len(pids)))
+}
+
+func continuityCounterLabel(streamType uint8) string {
+	switch streamType {
+	case 0x01, 0x02, 0x10, 0x1B, 0x24:
+		return "video"
+	case 0x03, 0x04, 0x0F, 0x11:
+		return "audio"
+	default:
+		return fmt.Sprintf("stream_type 0x%02x", streamType)
+	}
+}
+
+func errorWord(count int) string {
+	if count == 1 {
+		return "error"
+	}
+	return "errors"
+}
+
+func pidWord(count int) string {
+	if count == 1 {
+		return "PID"
+	}
+	return "PIDs"
+}

--- a/tsparser/continuity_counter_test.go
+++ b/tsparser/continuity_counter_test.go
@@ -1,0 +1,71 @@
+package tsparser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestContinuityCounterSummaryHealthy(t *testing.T) {
+	s := newContinuityCounterSummary(nil)
+	got := captureStdout(t, s.Dump)
+	want := "-----------------------------\nContinuity Counter: no errors detected\n"
+	if got != want {
+		t.Errorf("healthy summary:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestContinuityCounterSummaryErrors(t *testing.T) {
+	infos := []ProgramInfo{
+		{streamType: 0x1B, elementaryPid: 0x100},
+		{streamType: 0x0F, elementaryPid: 0x101},
+		{streamType: 0x06, elementaryPid: 0x102},
+	}
+	s := newContinuityCounterSummary(infos)
+	s.Add(0x101)
+	s.Add(0x100)
+	s.Add(0x100)
+	s.Add(0x999)
+
+	got := captureStdout(t, s.Dump)
+	for _, want := range []string{
+		"Continuity Counter Error Summary:",
+		"PID 0x0100 (video) : 2 errors",
+		"PID 0x0101 (audio) : 1 error",
+		"PID 0x0999 (unknown) : 1 error",
+		"Total              : 4 errors in 3 PIDs",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Index(got, "PID 0x0100") > strings.Index(got, "PID 0x0101") {
+		t.Errorf("PIDs are not sorted:\n%s", got)
+	}
+}
+
+func TestContinuityCounterLabelsAndPlurals(t *testing.T) {
+	for _, tt := range []struct {
+		streamType uint8
+		want       string
+	}{
+		{0x01, "video"}, {0x02, "video"}, {0x10, "video"}, {0x1B, "video"}, {0x24, "video"},
+		{0x03, "audio"}, {0x04, "audio"}, {0x0F, "audio"}, {0x11, "audio"},
+		{0x06, "stream_type 0x06"},
+	} {
+		if got := continuityCounterLabel(tt.streamType); got != tt.want {
+			t.Errorf("stream_type 0x%02x label = %q, want %q", tt.streamType, got, tt.want)
+		}
+	}
+	if got := errorWord(1); got != "error" {
+		t.Errorf("errorWord(1) = %q", got)
+	}
+	if got := errorWord(2); got != "errors" {
+		t.Errorf("errorWord(2) = %q", got)
+	}
+	if got := pidWord(1); got != "PID" {
+		t.Errorf("pidWord(1) = %q", got)
+	}
+	if got := pidWord(2); got != "PIDs" {
+		t.Errorf("pidWord(2) = %q", got)
+	}
+}

--- a/tsparser/mpeg_packet.go
+++ b/tsparser/mpeg_packet.go
@@ -98,6 +98,7 @@ func BufferPes(reader io.Reader, pos *int64, pmtPid, pcrPid uint16, programInfos
 	// found, so a healthy stream stays quiet. Only a cleanly parsed PES is
 	// checked — a partially parsed header would carry garbage timestamps.
 	anomaly := NewTimestampAnomaly()
+	continuity := newContinuityCounterSummary(programInfos)
 	checkAnomaly := func(perr error, pes *Pes) {
 		if perr == nil {
 			anomaly.Check(pes)
@@ -192,6 +193,7 @@ func BufferPes(reader io.Reader, pos *int64, pmtPid, pcrPid uint16, programInfos
 			pes.Append(tsPacket.Payload())
 		} else {
 			fmt.Printf("packet loss. : pid=0x%02x. count=0x%x, pos=0x%08x\n", pid, tsPacket.ContinuityCounter(), *pos)
+			continuity.Add(pid)
 		}
 
 		*pos += int64(size)
@@ -231,6 +233,7 @@ func BufferPes(reader io.Reader, pos *int64, pmtPid, pcrPid uint16, programInfos
 		bitrate.Dump()
 	}
 	anomaly.Dump()
+	continuity.Dump()
 
 	return nil
 }

--- a/tsparser/mpeg_packet_test.go
+++ b/tsparser/mpeg_packet_test.go
@@ -265,9 +265,22 @@ func TestBufferPesPacketLoss(t *testing.T) {
 
 	var pos int64
 	var opts options.Options
-	err = BufferPes(f2, &pos, 0x0030, 0x0031, programInfos, opts, 188, 0)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+	var bufferErr error
+	out := captureStdout(t, func() {
+		bufferErr = BufferPes(f2, &pos, 0x0030, 0x0031, programInfos, opts, 188, 0)
+	})
+	if bufferErr != nil {
+		t.Errorf("unexpected error: %s", bufferErr)
+	}
+	for _, want := range []string{
+		"packet loss. : pid=0x31. count=0x5",
+		"Continuity Counter Error Summary:",
+		"PID 0x0031 (video) : 1 error",
+		"Total              : 1 error in 1 PID",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("BufferPes output missing %q:\n%s", want, out)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- collect existing PES continuity counter violations by PID
- always print a healthy result or a deterministic per-PID error summary
- label known video and audio PIDs from PMT stream types
- document the always-on output and preserve the existing inline warnings

## Output examples

A healthy stream ends with:

~~~text
-----------------------------
Continuity Counter: no errors detected
~~~

When violations are detected, the existing inline warnings remain and the analysis ends with a per-PID summary:

~~~text
packet loss. : pid=0x100. count=0x5, pos=0x00123456
packet loss. : pid=0x100. count=0x9, pos=0x00234567
packet loss. : pid=0x101. count=0x3, pos=0x00345678
-----------------------------
Continuity Counter Error Summary:
  PID 0x0100 (video) : 2 errors
  PID 0x0101 (audio) : 1 error
  Total              : 3 errors in 2 PIDs
~~~

The summary counts detected continuity violations, not an estimate of how many transport packets were lost.

## TSDuck cross-check

The attached fixture was generated from the bundled 188-byte sample by changing the continuity counter of packet 154 and truncating the stream at that packet:

~~~sh
tsp \
  -I file sample_data/sample_188byte_video_mpeg2_320x240_25fps_audio_mp2_48000Hz.ts \
  -P filter --interval 0-154 \
  -P filter --interval 154 --set-label 1 \
  -P craft --only-label 1 --continuity-counter 0 \
  -O file mpeg-ts-analyzer-issue23-single-error.ts
~~~

Run the independent continuity check with:

~~~sh
tsp \
  -I file mpeg-ts-analyzer-issue23-single-error.ts \
  -P continuity --json-line \
  -O drop
~~~

TSDuck reports one discontinuity event at packet index 154 on PID 256 (`0x0100`). Running this branch against the same fixture reports one error on PID `0x0100`, so the event count and PID agree. TSDuck also reports an estimated six missing packets; this PR intentionally counts detected discontinuity events rather than estimated packet loss.

[Download the corrupted 188-byte TS fixture](https://github.com/user-attachments/files/31214876/mpeg-ts-analyzer-issue23-single-error.ts)

## Validation

- pre-push hook (format, lint, build, tests, and coverage)
- bitbuffer: 100.0% statement coverage
- tsparser: 100.0% statement coverage
- 192-byte M2TS smoke test: no errors detected
- TSDuck continuity plugin cross-check: both tools reported one discontinuity event on PID `0x0100`

Closes #23
