### PR TITLE
Implement spec-compliant continuity counter tracking

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -19,9 +19,13 @@ Continuity Counter: no errors detected
 
 ## Continuity counter summary (always on)
 
-Every continuity counter violation is still printed inline at the byte position
-where it is detected. A per-PID summary is always appended at the end so errors
-remain visible even when the analysis produces a large amount of output:
+A TS-layer tracker checks every non-null PID from the start of the selected
+program's PES analysis through the end of the analysis window. This includes
+repeated PSI/SI packets and unreferenced PIDs; PID `0x1FFF` null packets are
+excluded because their continuity counters are not required to form a sequence.
+Every violation is printed inline at the byte position where it is detected. A
+per-PID summary is always appended at the end so errors remain visible even when
+the analysis produces a large amount of output:
 
 ```
 packet loss. : pid=0x100. count=0x5, pos=0x00123456
@@ -34,8 +38,17 @@ Continuity Counter Error Summary:
   Total              : 3 errors in 2 PIDs
 ```
 
-The count is the number of violations reported by the existing PES continuity
-check. It does not estimate how many transport packets were lost.
+Counters advance modulo 16 only on packets whose header declares payload.
+Adaptation-field-only packets keep the current counter. An exact duplicate TS
+packet with the same counter is accepted and is not appended to PES data twice.
+A packet carrying `discontinuity_indicator` starts a new counter segment, and a
+PUSI packet follows the same rules as any other payload packet. After an
+undeclared mismatch, tracking resumes from the received counter so one fault
+produces one event instead of cascading warnings.
+
+The summary count is the number of discontinuity events, not an estimate of the
+number of missing transport packets. Known PAT, PMT, PCR, video, and audio PIDs
+receive labels; any other included PID is labeled `unknown`.
 
 ## Timestamp anomaly report (always on)
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ In addition, it can dump various MPEG-2 TS internal structures for stream invest
 
 Both 188-byte TS packets and 192-byte M2TS packets (BDAV format with TP_extra_header) are supported. The packet size is auto-detected from the stream.
 
+Continuity counters are checked at the TS layer for every non-null PID observed
+during the selected program's analysis, including PSI/SI and unreferenced PIDs.
+Counters advance only on payload packets, wrap from 15 to 0, accept exact
+duplicates, and start a new segment at `discontinuity_indicator`. PUSI packets
+are checked normally, adaptation-only packets do not advance the counter, and
+the tracker resynchronizes after each reported event. Null PID `0x1FFF` is
+excluded. The summary counts discontinuity events, not estimated missing
+packets; see [OPTIONS.md](OPTIONS.md#continuity-counter-summary-always-on).
+
 **Note:** The accuracy of the output is not guaranteed.
 
 # Install

--- a/tools/generate_continuity/README.md
+++ b/tools/generate_continuity/README.md
@@ -1,0 +1,14 @@
+# Continuity reference fixture
+
+Generate the deterministic fixture and check it with TSDuck:
+
+```sh
+go run ./tools/generate_continuity -output /tmp/continuity.ts
+tsp -I file /tmp/continuity.ts -P continuity --json-line -O drop
+```
+
+The stream includes legal 15-to-0 wraparound, an exact duplicate, an invalid
+same-counter packet, adaptation-only packets, a declared discontinuity, PUSI,
+one counter gap, recovery after each error, and arbitrary null-packet counters.
+TSDuck 3.44 reports two discontinuity events on PID `0x0100`: the invalid
+same-counter packet and the gap. It reports no cascade after either event.

--- a/tools/generate_continuity/main.go
+++ b/tools/generate_continuity/main.go
@@ -1,0 +1,82 @@
+// Command generate_continuity writes a deterministic MPEG-TS fixture for
+// cross-checking continuity-counter behavior with an independent analyzer.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+const (
+	packetSize = 188
+	testPID    = 0x0100
+	nullPID    = 0x1FFF
+)
+
+func payloadPacket(pid uint16, cc uint8, pusi bool, fill byte) []byte {
+	p := make([]byte, packetSize)
+	p[0] = 0x47
+	p[1] = byte(pid >> 8)
+	if pusi {
+		p[1] |= 0x40
+	}
+	p[2] = byte(pid)
+	p[3] = 0x10 | cc
+	for i := 4; i < len(p); i++ {
+		p[i] = fill
+	}
+	return p
+}
+
+func adaptationOnlyPacket(pid uint16, cc uint8, discontinuity bool) []byte {
+	p := make([]byte, packetSize)
+	p[0] = 0x47
+	p[1] = byte(pid >> 8)
+	p[2] = byte(pid)
+	p[3] = 0x20 | cc
+	p[4] = 183
+	if discontinuity {
+		p[5] = 0x80
+	}
+	for i := 6; i < len(p); i++ {
+		p[i] = 0xFF
+	}
+	return p
+}
+
+func main() {
+	output := flag.String("output", "continuity.ts", "output transport stream")
+	flag.Parse()
+
+	wrapped := payloadPacket(testPID, 0, false, 0x20)
+	packets := [][]byte{
+		payloadPacket(testPID, 15, false, 0x10),
+		wrapped,
+		wrapped,                                // legal exact duplicate
+		payloadPacket(testPID, 0, false, 0x30), // invalid same counter
+		payloadPacket(testPID, 1, false, 0x40), // resynchronized
+		adaptationOnlyPacket(testPID, 1, false),
+		payloadPacket(testPID, 2, false, 0x50),
+		adaptationOnlyPacket(testPID, 9, true), // declared discontinuity
+		payloadPacket(testPID, 10, false, 0x60),
+		payloadPacket(testPID, 11, true, 0x70),  // PUSI follows normal rules
+		payloadPacket(testPID, 14, false, 0x80), // gap: expected 12
+		payloadPacket(testPID, 15, false, 0x90), // resynchronized
+		payloadPacket(nullPID, 0, false, 0xFF),
+		payloadPacket(nullPID, 9, false, 0xFF), // null PID is excluded
+	}
+
+	f, err := os.Create(*output)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer func() { _ = f.Close() }()
+	for _, packet := range packets {
+		if _, err := f.Write(packet); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+}

--- a/tsparser/continuity_counter.go
+++ b/tsparser/continuity_counter.go
@@ -1,23 +1,95 @@
 package tsparser
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 )
 
-// continuityCounterSummary collects the continuity_counter violations already
-// detected while buffering PES packets. It does not change detection or
-// recovery behavior; it only makes the inline warnings visible as an end-of-run
-// summary.
+// continuityEvent describes one continuity_counter violation. Expected is the
+// value required by the previous packet on the PID; Actual is the value that
+// was observed. The tracker resynchronizes to Actual after returning the event.
+type continuityEvent struct {
+	PID      uint16
+	Expected uint8
+	Actual   uint8
+	Pos      int64
+}
+
+type continuityResult struct {
+	Event     *continuityEvent
+	Duplicate bool
+}
+
+type continuityState struct {
+	cc     uint8
+	packet []byte
+}
+
+// continuityTracker validates continuity counters independently of PSI or PES
+// assembly. It tracks every non-null PID passed to Check. State is bounded to
+// one 188-byte packet per observed PID so exact payload duplicates can be
+// distinguished from invalid same-counter packets.
+type continuityTracker struct {
+	states map[uint16]continuityState
+}
+
+func newContinuityTracker() *continuityTracker {
+	return &continuityTracker{states: make(map[uint16]continuityState)}
+}
+
+func (t *continuityTracker) Check(packet *TsPacket) continuityResult {
+	pid := packet.Pid()
+	if pid == nullPidValue {
+		return continuityResult{}
+	}
+
+	current := continuityState{
+		cc:     packet.ContinuityCounter(),
+		packet: append([]byte(nil), packet.buf...),
+	}
+	previous, seen := t.states[pid]
+	if !seen || packet.adaptationField.DiscontinuityIndicator() {
+		t.states[pid] = current
+		return continuityResult{}
+	}
+
+	if packet.HasPayload() && current.cc == previous.cc && bytes.Equal(current.packet, previous.packet) {
+		return continuityResult{Duplicate: true}
+	}
+
+	expected := previous.cc
+	if packet.HasPayload() {
+		expected = (expected + 1) & 0x0F
+	}
+	t.states[pid] = current
+	if current.cc == expected {
+		return continuityResult{}
+	}
+	return continuityResult{Event: &continuityEvent{
+		PID:      pid,
+		Expected: expected,
+		Actual:   current.cc,
+		Pos:      packet.pos,
+	}}
+}
+
+// continuityCounterSummary collects TS-layer continuity events and makes the
+// inline warnings visible as a deterministic end-of-run summary.
 type continuityCounterSummary struct {
 	counts map[uint16]int
 	labels map[uint16]string
 }
 
-func newContinuityCounterSummary(programInfos []ProgramInfo) *continuityCounterSummary {
+func newContinuityCounterSummary(pmtPid, pcrPid uint16, programInfos []ProgramInfo) *continuityCounterSummary {
 	s := &continuityCounterSummary{
 		counts: make(map[uint16]int),
 		labels: make(map[uint16]string),
+	}
+	s.labels[0] = "PAT"
+	s.labels[pmtPid] = "PMT"
+	if pcrPid != 0 && pcrPid != nullPidValue {
+		s.labels[pcrPid] = "PCR"
 	}
 	for _, info := range programInfos {
 		s.labels[info.elementaryPid] = continuityCounterLabel(info.streamType)

--- a/tsparser/continuity_counter_test.go
+++ b/tsparser/continuity_counter_test.go
@@ -6,7 +6,10 @@ import (
 )
 
 func TestContinuityCounterSummaryHealthy(t *testing.T) {
-	s := newContinuityCounterSummary(nil)
+	s := newContinuityCounterSummary(0x1000, 0x0100, nil)
+	if s.labels[0] != "PAT" || s.labels[0x1000] != "PMT" || s.labels[0x0100] != "PCR" {
+		t.Fatalf("standard PID labels = %#v", s.labels)
+	}
 	got := captureStdout(t, s.Dump)
 	want := "-----------------------------\nContinuity Counter: no errors detected\n"
 	if got != want {
@@ -20,7 +23,7 @@ func TestContinuityCounterSummaryErrors(t *testing.T) {
 		{streamType: 0x0F, elementaryPid: 0x101},
 		{streamType: 0x06, elementaryPid: 0x102},
 	}
-	s := newContinuityCounterSummary(infos)
+	s := newContinuityCounterSummary(0x1000, 0x0100, infos)
 	s.Add(0x101)
 	s.Add(0x100)
 	s.Add(0x100)
@@ -41,6 +44,69 @@ func TestContinuityCounterSummaryErrors(t *testing.T) {
 	if strings.Index(got, "PID 0x0100") > strings.Index(got, "PID 0x0101") {
 		t.Errorf("PIDs are not sorted:\n%s", got)
 	}
+}
+
+func continuityTestPacket(pid uint16, cc, afc uint8, pusi, discontinuity bool, content byte) *TsPacket {
+	p := NewTsPacket()
+	p.pid = pid
+	p.continuityCounter = cc
+	p.adaptationFieldControl = afc
+	p.payloadUnitStartIndicator = 0
+	if pusi {
+		p.payloadUnitStartIndicator = 1
+	}
+	if discontinuity {
+		p.adaptationField.discontinuityIndicator = 1
+	}
+	p.buf = append(p.buf, 0x47, byte(pid>>8), byte(pid), byte(afc<<4|cc), content)
+	return p
+}
+
+func TestContinuityTrackerRules(t *testing.T) {
+	tracker := newContinuityTracker()
+	checkOK := func(name string, packet *TsPacket) continuityResult {
+		t.Helper()
+		result := tracker.Check(packet)
+		if result.Event != nil {
+			t.Fatalf("%s: unexpected event: %+v", name, result.Event)
+		}
+		return result
+	}
+
+	checkOK("first payload", continuityTestPacket(0x100, 15, 1, false, false, 0x10))
+	checkOK("wraparound", continuityTestPacket(0x100, 0, 1, false, false, 0x20))
+	duplicate := checkOK("exact duplicate", continuityTestPacket(0x100, 0, 1, false, false, 0x20))
+	if !duplicate.Duplicate {
+		t.Error("exact duplicate was not identified")
+	}
+
+	invalidSame := tracker.Check(continuityTestPacket(0x100, 0, 1, false, false, 0x30))
+	if invalidSame.Event == nil || invalidSame.Event.Expected != 1 || invalidSame.Event.Actual != 0 {
+		t.Fatalf("invalid same-counter event = %+v", invalidSame.Event)
+	}
+	checkOK("resynchronized payload", continuityTestPacket(0x100, 1, 1, false, false, 0x40))
+	checkOK("adaptation only", continuityTestPacket(0x100, 1, 2, false, false, 0x50))
+	checkOK("payload after adaptation", continuityTestPacket(0x100, 2, 1, false, false, 0x60))
+	checkOK("declared discontinuity", continuityTestPacket(0x100, 9, 2, false, true, 0x70))
+	checkOK("after declared discontinuity", continuityTestPacket(0x100, 10, 1, false, false, 0x80))
+	checkOK("PUSI", continuityTestPacket(0x100, 11, 1, true, false, 0x90))
+
+	gap := tracker.Check(continuityTestPacket(0x100, 14, 1, false, false, 0xA0))
+	if gap.Event == nil || gap.Event.PID != 0x100 || gap.Event.Expected != 12 || gap.Event.Actual != 14 {
+		t.Fatalf("gap event = %+v", gap.Event)
+	}
+	if gap.Event.Pos != 0 {
+		t.Errorf("event pos = %d, want 0", gap.Event.Pos)
+	}
+	checkOK("resynchronized after gap", continuityTestPacket(0x100, 15, 1, false, false, 0xB0))
+
+	checkOK("first adaptation-only", continuityTestPacket(0x200, 3, 2, false, false, 0xC0))
+	badAdaptation := tracker.Check(continuityTestPacket(0x200, 4, 2, false, false, 0xD0))
+	if badAdaptation.Event == nil || badAdaptation.Event.Expected != 3 {
+		t.Fatalf("adaptation-only event = %+v", badAdaptation.Event)
+	}
+	checkOK("null packet excluded", continuityTestPacket(nullPidValue, 0, 1, false, false, 0xE0))
+	checkOK("null counter arbitrary", continuityTestPacket(nullPidValue, 9, 1, false, false, 0xF0))
 }
 
 func TestContinuityCounterLabelsAndPlurals(t *testing.T) {

--- a/tsparser/mpeg_packet.go
+++ b/tsparser/mpeg_packet.go
@@ -98,7 +98,8 @@ func BufferPes(reader io.Reader, pos *int64, pmtPid, pcrPid uint16, programInfos
 	// found, so a healthy stream stays quiet. Only a cleanly parsed PES is
 	// checked — a partially parsed header would carry garbage timestamps.
 	anomaly := NewTimestampAnomaly()
-	continuity := newContinuityCounterSummary(programInfos)
+	continuity := newContinuityCounterSummary(pmtPid, pcrPid, programInfos)
+	continuityTracker := newContinuityTracker()
 	checkAnomaly := func(perr error, pes *Pes) {
 		if perr == nil {
 			anomaly.Check(pes)
@@ -124,6 +125,12 @@ func BufferPes(reader io.Reader, pos *int64, pmtPid, pcrPid uint16, programInfos
 			return fmt.Errorf("failed to parse TS packet in BufferPes: %w", err)
 		}
 		pid := tsPacket.Pid()
+		continuityResult := continuityTracker.Check(tsPacket)
+		if continuityResult.Event != nil {
+			event := continuityResult.Event
+			fmt.Printf("packet loss. : pid=0x%02x. count=0x%x, pos=0x%08x\n", event.PID, event.Actual, event.Pos)
+			continuity.Add(event.PID)
+		}
 		if bitrate != nil {
 			bitrate.CountPacket(pid)
 		}
@@ -149,6 +156,10 @@ func BufferPes(reader io.Reader, pos *int64, pmtPid, pcrPid uint16, programInfos
 			lastPcrPos = *pos
 		}
 		if !exist {
+			*pos += int64(size)
+			continue
+		}
+		if continuityResult.Duplicate {
 			*pos += int64(size)
 			continue
 		}
@@ -181,19 +192,14 @@ func BufferPes(reader io.Reader, pos *int64, pmtPid, pcrPid uint16, programInfos
 				pesMap[pid] = pes
 			}
 			pes.Initialize(pid, *pos, lastPcr, lastPcrPos)
-			pes.SetContinuityCounter(tsPacket.ContinuityCounter())
 			pes.Append(tsPacket.Payload()) // read until pointer_field
 
-		} else if tsPacket.ContinuityCounter() == (pes.ContinuityCounter()+1)&0xF {
-			pes.SetContinuityCounter(tsPacket.ContinuityCounter())
+		} else {
 			if pes.nextPcr == 0 && lastPcr > pes.prevPcr {
 				pes.nextPcr = lastPcr
 				pes.nextPcrPos = lastPcrPos
 			}
 			pes.Append(tsPacket.Payload())
-		} else {
-			fmt.Printf("packet loss. : pid=0x%02x. count=0x%x, pos=0x%08x\n", pid, tsPacket.ContinuityCounter(), *pos)
-			continuity.Add(pid)
 		}
 
 		*pos += int64(size)

--- a/tsparser/mpeg_packet_test.go
+++ b/tsparser/mpeg_packet_test.go
@@ -249,10 +249,13 @@ func TestBufferPesPacketLoss(t *testing.T) {
 	// Write PCR packet
 	_, _ = f.Write(buildPcrPacket(0x0031, 13500))
 
-	// Write PES start packet (cc=0)
-	_, _ = f.Write(buildTsPacket(0x0031, true, 0, pesHeader))
+	// The PCR packet also carries payload at cc=0, so the PES start is cc=1.
+	// An exact duplicate is legal and must not be appended to the PES twice.
+	pesStart := buildTsPacket(0x0031, true, 1, pesHeader)
+	_, _ = f.Write(pesStart)
+	_, _ = f.Write(pesStart)
 
-	// Write continuation with cc gap (cc=5, expected 1) -> triggers packet loss printf
+	// Write continuation with cc gap (cc=5, expected 2) -> triggers packet loss printf
 	_, _ = f.Write(buildTsPacket(0x0031, false, 5, []byte{0x00, 0x01}))
 
 	_ = f.Close()

--- a/tsparser/ts_packet.go
+++ b/tsparser/ts_packet.go
@@ -64,6 +64,12 @@ func (tp *TsPacket) HasAf() bool {
 	return tp.adaptationFieldControl == 2 || tp.adaptationFieldControl == 3
 }
 
+// HasPayload reports whether the TS header declares a payload. Continuity
+// counter rules use adaptation_field_control, not the resulting slice length.
+func (tp *TsPacket) HasPayload() bool {
+	return tp.adaptationFieldControl == 1 || tp.adaptationFieldControl == 3
+}
+
 // Pcr return this TsPacket PCR.
 func (tp *TsPacket) Pcr() uint64 { return tp.adaptationField.Pcr() }
 


### PR DESCRIPTION
## Summary

- replace PES-coupled continuity checks with a dedicated per-PID TS-layer tracker
- handle payload/adaptation-only packets, exact duplicates, PUSI, declared discontinuities, wraparound, and post-error resynchronization
- include PSI/SI and unreferenced PIDs while excluding null packets, with documented deterministic summary semantics
- add a reproducible fixture for TSDuck continuity-plugin cross-checks

## Validation

- `.githooks/pre-push`
- 188-byte bundled sample: no continuity errors
- 192-byte bundled sample: no continuity errors
- TSDuck 3.44 reports the same two events as the tracker on the generated regression fixture
- `bitbuffer`: 100.0% statement coverage
- `tsparser`: 100.0% statement coverage

Closes #47
