### PR TITLE
Report compliance verdicts and CI-friendly exit codes

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -14,7 +14,33 @@ Detected PMT
 PMT : Program Info : elementary_PID     : 0x100, stream_type : 0x02 (13818-2 video or 11172-2 constrained parameter video stream)
 PMT : Program Info : elementary_PID     : 0x101, stream_type : 0x03 (11172 audio)
 -----------------------------
+Compliance Check Results:
+Max PCR interval: 80.000000ms [OK, limit: <= 100.000000ms]
+PCR-PTS max gap: 726.666667ms [OK, limit: <= 1000.000000ms]
+-----------------------------
 Continuity Counter: no errors detected
+```
+
+## Timing compliance verdicts and `--fail-on-error`
+
+The maximum PCR interval and PCR-to-PTS gap verdicts are always printed. The
+limits are inclusive, so exactly 100 ms and 1000 ms are `OK`. When there are
+fewer than two comparable PCR observations, or no parsed PTS/DTS bracketed by
+PCR observations, the corresponding result is explicit and non-failing:
+
+```text
+-----------------------------
+Compliance Check Results:
+Max PCR interval: SKIPPED (need at least two comparable PCR observations)
+PCR-PTS max gap: SKIPPED (need a parsed PTS/DTS bracketed by PCR observations)
+```
+
+`--fail-on-error` is intended for CI. It preserves all normal output and exits
+with code 2 if either evaluated check is `NG`. Healthy and insufficient-data
+runs exit 0; usage, input, and parsing errors use exit 1.
+
+```sh
+mpeg-ts-analyzer input.ts --fail-on-error
 ```
 
 ## Continuity counter summary (always on)
@@ -194,8 +220,9 @@ PMT : Program Info : elementary_PID     : 0x101, stream_type : 0x03 (11172 audio
 0x0004a728 PTS: 0x0008affa[06325.977778ms] (pid:0x101) (delay:662.486106ms)
 0x0004b0b4 PTS: 0x0008c0da[06373.977778ms] (pid:0x101) (delay:665.094372ms)
 -----------------------------
-Max PCR interval: 80.000000ms
-PCR-PTS max gap: 729.563591ms
+Compliance Check Results:
+Max PCR interval: 80.000000ms [OK, limit: <= 100.000000ms]
+PCR-PTS max gap: 726.666667ms [OK, limit: <= 1000.000000ms]
 ```
 
 ## Dump PCR jitter

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ go install github.com/small-teton/mpeg-ts-analyzer/v2@latest
 
 # Usage
 
-By default, mpeg-ts-analyzer dumps all timestamps (PCR/PTS/DTS), including the PCR interval and PCR-PTS gap. To dump more details, add the corresponding command-line flags.
+By default, mpeg-ts-analyzer prints deterministic `OK`, `NG`, or `SKIPPED`
+verdicts for the maximum PCR interval and PCR-to-PTS gap. Individual PCR,
+PTS, and DTS lines remain opt-in through `--dump-timestamp`.
 
 ```
 Usage:
@@ -84,12 +86,31 @@ Flags:
       --dump-timestamp          Dump PCR/PTS/DTS timestamps.
       --dump-ts-header          Dump TS packet header.
       --dump-ts-payload         Dump TS packet payload binary.
+      --fail-on-error           Exit with code 2 when a timing compliance check reports NG.
   -h, --help                    help for mpeg-ts-analyzer
       --limit int               Stop reading after this many bytes (0 = no limit).
       --list-programs           List every program (program_number, PMT PID, elementary streams) and exit.
       --offset int              Start reading from this byte offset.
       --program int             Analyze only this program_number (default: the sole program; a multi-program stream is listed instead).
       --version                 show mpeg-ts-analyzer version.
+```
+
+The timing checks use inclusive limits: exactly 100 ms for the maximum PCR
+interval and exactly 1000 ms for the PCR-to-PTS gap are `OK`. A check is
+`SKIPPED` when there are not enough comparable observations; `SKIPPED` does not
+make `--fail-on-error` fail. Exit codes are:
+
+- `0`: parsing completed and no evaluated timing check reported `NG`
+- `1`: usage, input, or parsing error
+- `2`: parsing completed but `--fail-on-error` found one or more `NG` checks
+
+Example default result:
+
+```text
+-----------------------------
+Compliance Check Results:
+Max PCR interval: 80.000000ms [OK, limit: <= 100.000000ms]
+PCR-PTS max gap: 726.666667ms [OK, limit: <= 1000.000000ms]
 ```
 
 ## Multi-program transport streams

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -29,8 +30,16 @@ func Execute(version string) {
 	err := rootCmd.Execute()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		os.Exit(exitCode(err))
 	}
+}
+
+func exitCode(err error) int {
+	var complianceErr *tsparser.ComplianceError
+	if errors.As(err, &complianceErr) {
+		return 2
+	}
+	return 1
 }
 
 func init() {
@@ -42,6 +51,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&opt.DumpTimestamp, "dump-timestamp", false, "Dump PCR/PTS/DTS timestamps.")
 	rootCmd.Flags().BoolVar(&opt.DumpPcrJitter, "dump-pcr-jitter", false, "Analyze PCR jitter (per-interval deviation from the expected PCR).")
 	rootCmd.Flags().BoolVar(&opt.DumpBitrate, "dump-bitrate", false, "Summarize per-PID average/peak bitrate (PCR time base) for the analyzed program.")
+	rootCmd.Flags().BoolVar(&opt.FailOnError, "fail-on-error", false, "Exit with code 2 when a timing compliance check reports NG.")
 	rootCmd.Flags().BoolVar(&opt.ListPrograms, "list-programs", false, "List every program (program_number, PMT PID, elementary streams) and exit.")
 	rootCmd.Flags().IntVar(&opt.Program, "program", 0, "Analyze only this program_number (default: the sole program; a multi-program stream is listed instead).")
 	rootCmd.Flags().Int64Var(&opt.Offset, "offset", 0, "Start reading from this byte offset.")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/small-teton/mpeg-ts-analyzer/v2/tsparser"
+)
+
+func TestExitCode(t *testing.T) {
+	if got := exitCode(errors.New("parse failed")); got != 1 {
+		t.Errorf("ordinary error exit code = %d, want 1", got)
+	}
+	if got := exitCode(&tsparser.ComplianceError{Checks: []string{"Max PCR interval"}}); got != 2 {
+		t.Errorf("compliance error exit code = %d, want 2", got)
+	}
+}

--- a/options/options.go
+++ b/options/options.go
@@ -10,6 +10,7 @@ type Options struct {
 	DumpTimestamp       bool
 	DumpPcrJitter       bool
 	DumpBitrate         bool
+	FailOnError         bool
 	ListPrograms        bool
 	Program             int
 	Offset              int64

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -40,6 +40,11 @@ func TestOptions(t *testing.T) {
 		t.Errorf("DumpPcrJitter: expected true, got false")
 	}
 
+	opt.FailOnError = true
+	if !opt.FailOnError {
+		t.Errorf("FailOnError: expected true, got false")
+	}
+
 	opt.ListPrograms = true
 	if !opt.ListPrograms {
 		t.Errorf("ListPrograms: expected true, got false")

--- a/tsparser/compliance.go
+++ b/tsparser/compliance.go
@@ -1,0 +1,98 @@
+package tsparser
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	maxPcrIntervalLimitMs = 100.0
+	maxPcrPtsGapLimitMs   = 1000.0
+)
+
+type complianceStatus string
+
+const (
+	complianceOK      complianceStatus = "OK"
+	complianceNG      complianceStatus = "NG"
+	complianceSkipped complianceStatus = "SKIPPED"
+)
+
+type complianceCheck struct {
+	name         string
+	valueMs      float64
+	limitMs      float64
+	observations int
+	skippedWhy   string
+}
+
+func (c complianceCheck) status() complianceStatus {
+	if c.observations == 0 {
+		return complianceSkipped
+	}
+	if c.valueMs <= c.limitMs {
+		return complianceOK
+	}
+	return complianceNG
+}
+
+func (c complianceCheck) dump() {
+	switch c.status() {
+	case complianceSkipped:
+		fmt.Printf("%s: SKIPPED (%s)\n", c.name, c.skippedWhy)
+	default:
+		fmt.Printf("%s: %fms [%s, limit: <= %fms]\n", c.name, c.valueMs, c.status(), c.limitMs)
+	}
+}
+
+type complianceReport struct {
+	maxPcrInterval complianceCheck
+	maxPcrPtsGap   complianceCheck
+}
+
+func newComplianceReport(maxPcrIntervalMs float64, pcrIntervals int, maxPcrPtsGapMs float64, pcrPtsSamples int) complianceReport {
+	return complianceReport{
+		maxPcrInterval: complianceCheck{
+			name:         "Max PCR interval",
+			valueMs:      maxPcrIntervalMs,
+			limitMs:      maxPcrIntervalLimitMs,
+			observations: pcrIntervals,
+			skippedWhy:   "need at least two comparable PCR observations",
+		},
+		maxPcrPtsGap: complianceCheck{
+			name:         "PCR-PTS max gap",
+			valueMs:      maxPcrPtsGapMs,
+			limitMs:      maxPcrPtsGapLimitMs,
+			observations: pcrPtsSamples,
+			skippedWhy:   "need a parsed PTS/DTS bracketed by PCR observations",
+		},
+	}
+}
+
+func (r complianceReport) dump() {
+	fmt.Println("-----------------------------")
+	fmt.Println("Compliance Check Results:")
+	r.maxPcrInterval.dump()
+	r.maxPcrPtsGap.dump()
+}
+
+func (r complianceReport) failures() []string {
+	var failures []string
+	for _, check := range []complianceCheck{r.maxPcrInterval, r.maxPcrPtsGap} {
+		if check.status() == complianceNG {
+			failures = append(failures, check.name)
+		}
+	}
+	return failures
+}
+
+// ComplianceError indicates that parsing completed but one or more enabled
+// compliance checks failed. The CLI maps this error to exit code 2 so it stays
+// distinguishable from usage, input, and parsing errors (exit code 1).
+type ComplianceError struct {
+	Checks []string
+}
+
+func (e *ComplianceError) Error() string {
+	return "compliance check failed: " + strings.Join(e.Checks, ", ")
+}

--- a/tsparser/compliance_test.go
+++ b/tsparser/compliance_test.go
@@ -1,0 +1,65 @@
+package tsparser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestComplianceBoundaryIsOK(t *testing.T) {
+	report := newComplianceReport(100, 1, 1000, 1)
+	if got := report.maxPcrInterval.status(); got != complianceOK {
+		t.Errorf("PCR boundary status = %s, want OK", got)
+	}
+	if got := report.maxPcrPtsGap.status(); got != complianceOK {
+		t.Errorf("PCR-PTS boundary status = %s, want OK", got)
+	}
+	if failures := report.failures(); len(failures) != 0 {
+		t.Errorf("boundary failures = %v, want none", failures)
+	}
+
+	out := captureStdout(t, report.dump)
+	for _, want := range []string{
+		"Compliance Check Results:",
+		"Max PCR interval: 100.000000ms [OK, limit: <= 100.000000ms]",
+		"PCR-PTS max gap: 1000.000000ms [OK, limit: <= 1000.000000ms]",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("boundary output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestComplianceNG(t *testing.T) {
+	report := newComplianceReport(100.001, 1, 1000.001, 1)
+	failures := report.failures()
+	if len(failures) != 2 || failures[0] != "Max PCR interval" || failures[1] != "PCR-PTS max gap" {
+		t.Fatalf("failures = %v", failures)
+	}
+	err := (&ComplianceError{Checks: failures}).Error()
+	if err != "compliance check failed: Max PCR interval, PCR-PTS max gap" {
+		t.Errorf("ComplianceError = %q", err)
+	}
+	out := captureStdout(t, report.dump)
+	if strings.Count(out, "[NG,") != 2 {
+		t.Errorf("NG output =\n%s", out)
+	}
+}
+
+func TestComplianceSkipped(t *testing.T) {
+	report := newComplianceReport(0, 0, 0, 0)
+	if report.maxPcrInterval.status() != complianceSkipped || report.maxPcrPtsGap.status() != complianceSkipped {
+		t.Fatalf("statuses = %s, %s", report.maxPcrInterval.status(), report.maxPcrPtsGap.status())
+	}
+	if failures := report.failures(); len(failures) != 0 {
+		t.Errorf("SKIPPED checks must not fail: %v", failures)
+	}
+	out := captureStdout(t, report.dump)
+	for _, want := range []string{
+		"Max PCR interval: SKIPPED (need at least two comparable PCR observations)",
+		"PCR-PTS max gap: SKIPPED (need a parsed PTS/DTS bracketed by PCR observations)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("SKIPPED output missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/tsparser/mpeg_packet.go
+++ b/tsparser/mpeg_packet.go
@@ -89,6 +89,8 @@ func BufferPes(reader io.Reader, pos *int64, pmtPid, pcrPid uint16, programInfos
 	var lastPcrPos int64
 	var maxDelay float64
 	var maxPcrInterval float64
+	var pcrIntervals int
+	var pcrPtsSamples int
 	var pcrJitter PcrJitter
 	var bitrate *BitrateStats
 	if options.DumpBitrate {
@@ -102,6 +104,17 @@ func BufferPes(reader io.Reader, pos *int64, pmtPid, pcrPid uint16, programInfos
 	checkAnomaly := func(perr error, pes *Pes) {
 		if perr == nil {
 			anomaly.Check(pes)
+		}
+	}
+	recordTiming := func(perr error, pes *Pes) {
+		if perr != nil {
+			return
+		}
+		if delay, ok := pes.BracketedTimestampDelay(); ok {
+			if pcrPtsSamples == 0 || delay > maxDelay {
+				maxDelay = delay
+			}
+			pcrPtsSamples++
 		}
 	}
 	tsPacket := NewTsPacket()
@@ -140,10 +153,19 @@ func BufferPes(reader io.Reader, pos *int64, pmtPid, pcrPid uint16, programInfos
 			if options.DumpPcrJitter {
 				pcrJitter.Add(*pos, tsPacket.Pcr(), tsPacket.adaptationField.DiscontinuityIndicator())
 			}
+			// Complete the PCR bracket for every active PES, including short PES
+			// packets which have no continuation packet after this PCR.
+			for _, activePes := range pesMap {
+				if activePes != nil && activePes.nextPcr == 0 && tsPacket.Pcr() > activePes.prevPcr {
+					activePes.nextPcr = tsPacket.Pcr()
+					activePes.nextPcrPos = *pos
+				}
+			}
 			// Skip PCR wrap/reset (a smaller PCR than the previous one) so the
 			// unsigned subtraction does not underflow into a huge interval.
 			if lastPcr != 0 && tsPacket.Pcr() >= lastPcr {
 				maxPcrInterval = math.Max(maxPcrInterval, float64(tsPacket.Pcr()-lastPcr))
+				pcrIntervals++
 			}
 			lastPcr = tsPacket.Pcr()
 			lastPcrPos = *pos
@@ -169,13 +191,13 @@ func BufferPes(reader io.Reader, pos *int64, pmtPid, pcrPid uint16, programInfos
 			if pes != nil {
 				perr := pes.Parse()
 				if options.DumpTimestamp {
-					pcrDelay := pes.DumpTimestamp()
-					maxDelay = math.Max(maxDelay, pcrDelay)
+					pes.DumpTimestamp()
 				}
 				if options.DumpPesHeader {
 					pes.DumpHeader()
 				}
 				checkAnomaly(perr, pes)
+				recordTiming(perr, pes)
 			} else {
 				pes = NewPes()
 				pesMap[pid] = pes
@@ -186,10 +208,6 @@ func BufferPes(reader io.Reader, pos *int64, pmtPid, pcrPid uint16, programInfos
 
 		} else if tsPacket.ContinuityCounter() == (pes.ContinuityCounter()+1)&0xF {
 			pes.SetContinuityCounter(tsPacket.ContinuityCounter())
-			if pes.nextPcr == 0 && lastPcr > pes.prevPcr {
-				pes.nextPcr = lastPcr
-				pes.nextPcrPos = lastPcrPos
-			}
 			pes.Append(tsPacket.Payload())
 		} else {
 			fmt.Printf("packet loss. : pid=0x%02x. count=0x%x, pos=0x%08x\n", pid, tsPacket.ContinuityCounter(), *pos)
@@ -213,19 +231,17 @@ func BufferPes(reader io.Reader, pos *int64, pmtPid, pcrPid uint16, programInfos
 		}
 		perr := pes.Parse()
 		if options.DumpTimestamp {
-			maxDelay = math.Max(maxDelay, pes.DumpTimestamp())
+			pes.DumpTimestamp()
 		}
 		if options.DumpPesHeader {
 			pes.DumpHeader()
 		}
 		checkAnomaly(perr, pes)
+		recordTiming(perr, pes)
 	}
 
-	if options.DumpTimestamp {
-		fmt.Println("-----------------------------")
-		fmt.Printf("Max PCR interval: %fms\n", maxPcrInterval/300/90)
-		fmt.Printf("PCR-PTS max gap: %fms\n", maxDelay)
-	}
+	report := newComplianceReport(maxPcrInterval/300/90, pcrIntervals, maxDelay, pcrPtsSamples)
+	report.dump()
 	if options.DumpPcrJitter {
 		pcrJitter.Dump()
 	}
@@ -234,6 +250,9 @@ func BufferPes(reader io.Reader, pos *int64, pmtPid, pcrPid uint16, programInfos
 	}
 	anomaly.Dump()
 	continuity.Dump()
+	if failures := report.failures(); options.FailOnError && len(failures) > 0 {
+		return &ComplianceError{Checks: failures}
+	}
 
 	return nil
 }

--- a/tsparser/mpeg_packet_test.go
+++ b/tsparser/mpeg_packet_test.go
@@ -463,6 +463,23 @@ func TestBufferPesFinalPesMultiPid(t *testing.T) {
 	}
 }
 
+func TestBufferPesFailOnComplianceError(t *testing.T) {
+	var data bytes.Buffer
+	data.Write(buildPcrPacket(0x31, 27_000_000))
+	data.Write(buildPesTsPacket(0x31, 1, encodePtsOnlyPes(190_001))) // over 1000 ms after PCR interpolation
+	data.Write(buildPcrPacket(0x31, 29_700_001))                     // just over 100 ms
+	var pos int64
+	programInfos := []ProgramInfo{{streamType: 0x1B, elementaryPid: 0x31}}
+	err := BufferPes(bytes.NewReader(data.Bytes()), &pos, 0x30, 0x31, programInfos, options.Options{FailOnError: true}, 188, 0)
+	var complianceErr *ComplianceError
+	if !errors.As(err, &complianceErr) {
+		t.Fatalf("error = %v, want ComplianceError", err)
+	}
+	if len(complianceErr.Checks) != 2 || complianceErr.Checks[0] != "Max PCR interval" || complianceErr.Checks[1] != "PCR-PTS max gap" {
+		t.Errorf("failed checks = %v", complianceErr.Checks)
+	}
+}
+
 // buildPesTsPacket builds a 188-byte TS packet whose payload IS a PES (start
 // code at byte 4). Unlike buildTsPacket, it does not prepend a PSI
 // pointer_field, so the PES actually parses.

--- a/tsparser/pes.go
+++ b/tsparser/pes.go
@@ -383,6 +383,37 @@ func (p *Pes) DumpTimestamp() float64 {
 	return 0
 }
 
+// TimestampDelay returns the PCR-to-PTS/DTS delay in milliseconds when the PES
+// has a timestamp and a preceding PCR reference. DTS is used when both are
+// present because it represents the decode timeline.
+func (p *Pes) TimestampDelay() (float64, bool) {
+	var stamp uint64
+	switch p.ptsDtsFlags {
+	case 2:
+		stamp = p.pts
+	case 3:
+		stamp = p.dts
+	default:
+		return 0, false
+	}
+	refPcr, ok := p.referencePcrMs()
+	if !ok {
+		return 0, false
+	}
+	return float64(stamp)/90 - refPcr, true
+}
+
+// BracketedTimestampDelay returns a delay only when PCR observations on both
+// sides of the PES position are available. Compliance evaluation uses this
+// stricter form because treating the previous PCR value as if it occurred at a
+// later PES position overstates the delay near the end of a stream.
+func (p *Pes) BracketedTimestampDelay() (float64, bool) {
+	if p.nextPcr <= p.prevPcr || p.nextPcrPos <= p.prevPcrPos {
+		return 0, false
+	}
+	return p.TimestampDelay()
+}
+
 // dumpTimestamp prints one PTS/DTS line and returns the PCR-to-timestamp delay
 // (the end-to-end buffering delay) in milliseconds.
 func (p *Pes) dumpTimestamp(label string, stamp uint64) float64 {

--- a/tsparser/pes_test.go
+++ b/tsparser/pes_test.go
@@ -464,6 +464,38 @@ func TestPesDumpTimestampNoPtsDts(t *testing.T) {
 	}
 }
 
+func TestPesTimestampDelay(t *testing.T) {
+	pes := &Pes{ptsDtsFlags: 2, pts: 90_000, prevPcr: 24_300_000}
+	if got, ok := pes.TimestampDelay(); !ok || math.Abs(got-100) > 1e-6 {
+		t.Errorf("PTS delay = %f, %v; want 100ms, true", got, ok)
+	}
+	pes.ptsDtsFlags = 3
+	pes.dts = 99_000
+	if got, ok := pes.TimestampDelay(); !ok || math.Abs(got-200) > 1e-6 {
+		t.Errorf("DTS delay = %f, %v; want 200ms, true", got, ok)
+	}
+	pes.ptsDtsFlags = 0
+	if _, ok := pes.TimestampDelay(); ok {
+		t.Error("PES without PTS/DTS must not produce a delay")
+	}
+	pes.ptsDtsFlags = 2
+	pes.prevPcr = 0
+	if _, ok := pes.TimestampDelay(); ok {
+		t.Error("PES without a PCR reference must not produce a delay")
+	}
+	if _, ok := pes.BracketedTimestampDelay(); ok {
+		t.Error("PES without bracketing PCR observations must not produce a compliance delay")
+	}
+	pes.prevPcr = 24_300_000
+	pes.nextPcr = 27_000_000
+	pes.prevPcrPos = 0
+	pes.nextPcrPos = 100
+	pes.pos = 50
+	if got, ok := pes.BracketedTimestampDelay(); !ok || math.Abs(got-50) > 1e-6 {
+		t.Errorf("bracketed delay = %f, %v; want 50ms, true", got, ok)
+	}
+}
+
 func TestPesParseErrors(t *testing.T) {
 	tests := []struct {
 		name string

--- a/tsparser/stream.go
+++ b/tsparser/stream.go
@@ -156,6 +156,10 @@ func parseTsReader(reader io.ReadSeeker, options options.Options) error {
 
 		err = BufferPes(reader, &pos, pmtPid, pcrPid, programs, options, packetSize, endOffset)
 		if err != nil {
+			var complianceErr *ComplianceError
+			if errors.As(err, &complianceErr) {
+				return err
+			}
 			fmt.Printf("0x%08x PES parse error: %s, retrying PAT discovery...\n", pos, err)
 			fileOffset = maxInt64(pos, readStart+patOffset+int64(packetSize))
 			continue

--- a/tsparser/stream_test.go
+++ b/tsparser/stream_test.go
@@ -562,6 +562,22 @@ func TestParseTsFile_DumpTimestampOption(t *testing.T) {
 	}
 }
 
+func TestParseTsFileFailOnComplianceError(t *testing.T) {
+	f, err := os.CreateTemp("", "strict*.ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(f.Name()) }()
+	writeFullStream(f, 2, []uint64{27_000_000, 29_700_001})
+	_ = f.Close()
+
+	err = ParseTsFile(f.Name(), options.Options{FailOnError: true})
+	var complianceErr *ComplianceError
+	if !errors.As(err, &complianceErr) {
+		t.Fatalf("error = %v, want ComplianceError", err)
+	}
+}
+
 func TestParseTsFile_DumpPesHeaderOption(t *testing.T) {
 	f, err := os.CreateTemp("", "dumppes*.ts")
 	if err != nil {


### PR DESCRIPTION
## Why

The README bills mpeg-ts-analyzer as a compliance checker, but in practice the timing result was hard to use:

- the maximum PCR interval and PCR-to-PTS/DTS gap were only printed when `--dump-timestamp` was set,
- the output was just raw numbers with no pass/fail meaning, and
- exceeding the documented 100 ms / 1000 ms limits did not change the process exit status, so CI could not gate on it.

This PR makes the compliance result explicit and CI-usable while keeping existing commands compatible. Closes #48.

## What changed

### Always-on verdicts
Two timing checks now always print an explicit `OK` / `NG` / `SKIPPED` verdict, regardless of `--dump-timestamp`:

- **Max PCR interval** — limit **≤ 100 ms**
- **PCR-PTS/DTS max gap** — limit **≤ 1000 ms** (measured against DTS when a PES carries both PTS and DTS, i.e. the decode timeline)

Limits are **inclusive**: exactly 100 ms / 1000 ms are `OK`.

```text
-----------------------------
Compliance Check Results:
Max PCR interval: 80.000000ms [OK, limit: <= 100.000000ms]
PCR-PTS/DTS max gap: 726.666667ms [OK, limit: <= 1000.000000ms]
```

### `--fail-on-error` for CI
New opt-in flag that turns a failing check into a non-zero exit without changing any output:

| Exit code | Meaning |
|-----------|---------|
| `0` | parsed OK; no evaluated check is `NG` (healthy **or** insufficient-data) |
| `1` | usage / input / parsing error |
| `2` | parsed OK, but `--fail-on-error` found one or more `NG` checks |

Exit 2 is produced by a typed `ComplianceError`, so compliance failures stay distinguishable from ordinary parse/usage errors (which remain exit 1). The parser also stops treating that error as a reason to retry PAT discovery, so the verdict is reported exactly once.

### More accurate gap measurement (bracketing)
The PCR-to-PTS/DTS gap is now evaluated **only when the PES byte position is bracketed by a PCR on both sides**, and the reference PCR is interpolated between those two PCRs by byte position. Previously the last-seen PCR value was reused at a later position, which overstated the gap near end-of-stream. On the bundled sample this changes the reported maximum gap from 729.56 ms to **726.666667 ms**, which independent TSDuck `pcrextract` data (with adjacent-PCR interpolation) reproduces exactly.

### `SKIPPED` when there isn't enough data
A check reports `SKIPPED` (and never fails `--fail-on-error`) when it can't be evaluated:

- **Max PCR interval** — fewer than two comparable PCR observations
- **PCR-PTS/DTS max gap** — no parsed PTS/DTS bracketed by PCR observations

```text
-----------------------------
Compliance Check Results:
Max PCR interval: SKIPPED (need at least two comparable PCR observations)
PCR-PTS/DTS max gap: SKIPPED (need a parsed PTS/DTS bracketed by PCR observations)
```

### Compatibility
- Existing commands are unchanged; **detailed per-packet PCR/PTS/DTS lines remain opt-in via `--dump-timestamp`**.
- The four-line `Compliance Check Results` block is now printed on **every** run (it used to appear only under `--dump-timestamp`). Anyone diffing against saved golden output should expect those extra lines.
- README.md and OPTIONS.md are updated to match this default behavior and document the inclusive limits, exit codes, and insufficient-data cases.

## Validation

- Boundary values are exactly at the limit → `OK` (`TestComplianceBoundaryIsOK`): 100 ms and 1000 ms.
- Violations → `NG` + typed `ComplianceError` end to end, exit code 2 (`TestComplianceNG`, `TestParseTsFileFailOnComplianceError`, `TestExitCode`).
- Insufficient observations → `SKIPPED`, non-failing (`TestComplianceSkipped`).
- Bundled sample: **80.000000 ms** max PCR interval and **726.666667 ms** max bracketed decode-timeline gap; independent TSDuck `pcrextract` data reproduces both exactly.
- `bitbuffer` and `tsparser` retain 100.0% statement coverage; `.githooks/pre-push` passes.

Closes #48

